### PR TITLE
"お届け先を指定"チェックボックスにチェックがないと"お届け先を複数指定する"ボタンが表示されない不具合の修正(SP)。

### DIFF
--- a/data/Smarty/templates/sphone/shopping/nonmember_input.tpl
+++ b/data/Smarty/templates/sphone/shopping/nonmember_input.tpl
@@ -401,13 +401,13 @@
                         style="<!--{$arrErr[$key3]|sfGetErrorColor}-->"
                         class="boxShort text data-role-none" />
                 </dd>
-                <!--{if $smarty.const.USE_MULTIPLE_SHIPPING !== false}-->
-                    <dd class="pb">
-                        <a class="btn_more" href="javascript:eccube.setModeAndSubmit('multiple', '', '');">お届け先を複数指定する</a>
-                    </dd>
-                <!--{/if}-->
             </div>
 
+            <!--{if $smarty.const.USE_MULTIPLE_SHIPPING !== false}-->
+                <dd class="pb">
+                    <a class="btn_more" href="javascript:eccube.setModeAndSubmit('multiple', '', '');">お届け先を複数指定する</a>
+                </dd>
+            <!--{/if}-->
             <div class="btn_area">
                 <p><input type="submit" value="次へ" class="btn data-role-none" alt="次へ" name="next" id="next" /></p>
             </div>


### PR DESCRIPTION
ボタンの表示位置を変更、PC同様にお届け先の複数指定ができるよう修正。
issue #29 