### PR TITLE
商品登録の確認画面で数字の先頭の0を除去

### DIFF
--- a/data/class/pages/admin/products/LC_Page_Admin_Products_Product.php
+++ b/data/class/pages/admin/products/LC_Page_Admin_Products_Product.php
@@ -323,18 +323,18 @@ class LC_Page_Admin_Products_Product extends LC_Page_Admin_Products_Ex
             $objFormParam->addParam('temp_down_file', 'temp_down_file', '', '', array());
             $objFormParam->addParam('save_down_file', 'save_down_file', '', '', array());
             $objFormParam->addParam('商品コード', 'product_code', STEXT_LEN, 'KVa', array('EXIST_CHECK', 'SPTAB_CHECK', 'MAX_LENGTH_CHECK'));
-            $objFormParam->addParam(NORMAL_PRICE_TITLE, 'price01', PRICE_LEN, 'n', array('NUM_CHECK', 'MAX_LENGTH_CHECK'));
-            $objFormParam->addParam(SALE_PRICE_TITLE, 'price02', PRICE_LEN, 'n', array('EXIST_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK'));
+            $objFormParam->addParam(NORMAL_PRICE_TITLE, 'price01', PRICE_LEN, 'n', array('NUM_CHECK', 'MAX_LENGTH_CHECK', 'ZERO_START'));
+            $objFormParam->addParam(SALE_PRICE_TITLE, 'price02', PRICE_LEN, 'n', array('EXIST_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK', 'ZERO_START'));
             if (OPTION_PRODUCT_TAX_RULE) {
                 $objFormParam->addParam('消費税率', 'tax_rate', PERCENTAGE_LEN, 'n', array('EXIST_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK'));
             }
-            $objFormParam->addParam('在庫数', 'stock', AMOUNT_LEN, 'n', array('SPTAB_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK'));
+            $objFormParam->addParam('在庫数', 'stock', AMOUNT_LEN, 'n', array('SPTAB_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK', 'ZERO_START'));
             $objFormParam->addParam('在庫無制限', 'stock_unlimited', INT_LEN, 'n', array('SPTAB_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK'));
         }
-        $objFormParam->addParam('商品送料', 'deliv_fee', PRICE_LEN, 'n', array('NUM_CHECK', 'SPTAB_CHECK', 'MAX_LENGTH_CHECK'));
-        $objFormParam->addParam('ポイント付与率', 'point_rate', PERCENTAGE_LEN, 'n', array('EXIST_CHECK', 'NUM_CHECK', 'SPTAB_CHECK', 'MAX_LENGTH_CHECK'));
+        $objFormParam->addParam('商品送料', 'deliv_fee', PRICE_LEN, 'n', array('NUM_CHECK', 'SPTAB_CHECK', 'MAX_LENGTH_CHECK', 'ZERO_START'));
+        $objFormParam->addParam('ポイント付与率', 'point_rate', PERCENTAGE_LEN, 'n', array('EXIST_CHECK', 'NUM_CHECK', 'SPTAB_CHECK', 'MAX_LENGTH_CHECK', 'ZERO_START'));
         $objFormParam->addParam('発送日目安', 'deliv_date_id', INT_LEN, 'n', array('NUM_CHECK'));
-        $objFormParam->addParam('販売制限数', 'sale_limit', AMOUNT_LEN, 'n', array('SPTAB_CHECK', 'ZERO_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK'));
+        $objFormParam->addParam('販売制限数', 'sale_limit', AMOUNT_LEN, 'n', array('SPTAB_CHECK', 'ZERO_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK', 'ZERO_START'));
         $objFormParam->addParam('メーカー', 'maker_id', INT_LEN, 'n', array('NUM_CHECK'));
         $objFormParam->addParam('メーカーURL', 'comment1', URL_LEN, 'a', array('SPTAB_CHECK', 'URL_CHECK', 'MAX_LENGTH_CHECK'));
         $objFormParam->addParam('検索ワード', 'comment3', LLTEXT_LEN, 'KVa', array('SPTAB_CHECK', 'MAX_LENGTH_CHECK'));
@@ -642,14 +642,6 @@ class LC_Page_Admin_Products_Product extends LC_Page_Admin_Products_Ex
         $arrForm['arrFile'] = $objUpFile->getFormFileList(IMAGE_TEMP_URLPATH, IMAGE_SAVE_URLPATH);
         // ダウンロード商品実ファイル名取得
         $arrForm['down_realfilename'] = $objDownFile->getFormDownFile();
-
-        // 数字の先頭の0を除去
-        $arrForm['price01']    = $arrForm['price01']    != "" ? (int)$arrForm['price01'] : "";
-        $arrForm['price02']    = $arrForm['price02']    != "" ? (int)$arrForm['price02'] : "";
-        $arrForm['stock']      = $arrForm['stock']      != "" ? (int)$arrForm['stock'] : "";
-        $arrForm['deliv_fee']  = $arrForm['deliv_fee']  != "" ? (int)$arrForm['deliv_fee'] : "";
-        $arrForm['point_rate'] = $arrForm['point_rate'] != "" ? (int)$arrForm['point_rate'] : "";
-        $arrForm['sale_limit'] = $arrForm['sale_limit'] != "" ? (int)$arrForm['sale_limit'] : "";
 
         return $arrForm;
     }

--- a/data/class/pages/admin/products/LC_Page_Admin_Products_Product.php
+++ b/data/class/pages/admin/products/LC_Page_Admin_Products_Product.php
@@ -643,6 +643,14 @@ class LC_Page_Admin_Products_Product extends LC_Page_Admin_Products_Ex
         // ダウンロード商品実ファイル名取得
         $arrForm['down_realfilename'] = $objDownFile->getFormDownFile();
 
+        // 数字の先頭の0を除去
+        $arrForm['price01']    = $arrForm['price01']    != "" ? (int)$arrForm['price01'] : "";
+        $arrForm['price02']    = $arrForm['price02']    != "" ? (int)$arrForm['price02'] : "";
+        $arrForm['stock']      = $arrForm['stock']      != "" ? (int)$arrForm['stock'] : "";
+        $arrForm['deliv_fee']  = $arrForm['deliv_fee']  != "" ? (int)$arrForm['deliv_fee'] : "";
+        $arrForm['point_rate'] = $arrForm['point_rate'] != "" ? (int)$arrForm['point_rate'] : "";
+        $arrForm['sale_limit'] = $arrForm['sale_limit'] != "" ? (int)$arrForm['sale_limit'] : "";
+
         return $arrForm;
     }
 


### PR DESCRIPTION
商品登録画面にて、販売価格などの項目に0から始まる数字("0100"など)を入力した際に確認ページでそのまま表示されてしまうという問題を解決するために確認ページで表示する前に数字の先頭の0を除去するようにしました。ただし、0のみからなる数字("000"など)は0と表示するようにしました。
issue #35 