### PR TITLE
#38 定休日管理のタイトルの字数制限が表記と異なっていたため修正

### DIFF
--- a/data/class/pages/admin/basis/LC_Page_Admin_Basis_Holiday.php
+++ b/data/class/pages/admin/basis/LC_Page_Admin_Basis_Holiday.php
@@ -165,7 +165,7 @@ class LC_Page_Admin_Basis_Holiday extends LC_Page_Admin_Ex
         switch ($mode) {
             case 'edit':
             case 'pre_edit':
-                $objFormParam->addParam('タイトル', 'title', STEXT_LEN, 'KVa', array('EXIST_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
+                $objFormParam->addParam('タイトル', 'title', SMTEXT_LEN, 'KVa', array('EXIST_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
                 $objFormParam->addParam('月', 'month', INT_LEN, 'n', array('SELECT_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
                 $objFormParam->addParam('日', 'day', INT_LEN, 'n', array('SELECT_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
                 $objFormParam->addParam('定休日ID', 'holiday_id', INT_LEN, 'n', array('NUM_CHECK', 'MAX_LENGTH_CHECK'));


### PR DESCRIPTION
#38 定休日管理のタイトルの字数制限が表記と異なっていたため修正  
51文字以上の文字列を弾いていたものを101文字以上の文字列を弾くように修正しました