### PR TITLE
#40 帳票の発行日の文言を統一

### DIFF
--- a/data/class/SC_Fpdf.php
+++ b/data/class/SC_Fpdf.php
@@ -70,7 +70,6 @@ class SC_Fpdf extends SC_Helper_FPDI
 
     public function setData($arrData)
     {
-        GC_Utils::gfPrintLog(print_r($arrDisp,true));
         $this->arrData = $arrData;
 
         // ページ番号よりIDを取得

--- a/data/class/SC_Fpdf.php
+++ b/data/class/SC_Fpdf.php
@@ -138,8 +138,8 @@ class SC_Fpdf extends SC_Helper_FPDI
         $this->lfText(27, 70, $this->arrData['msg1'], 8);  //メッセージ1
         $this->lfText(27, 74, $this->arrData['msg2'], 8);  //メッセージ2
         $this->lfText(27, 78, $this->arrData['msg3'], 8);  //メッセージ3
-        $text = '作成日: '.$this->arrData['year'].'年'.$this->arrData['month'].'月'.$this->arrData['day'].'日';
-        $this->lfText(158, 288, $text, 8);  //作成日
+        $text = '発行日: '.$this->arrData['year'].'年'.$this->arrData['month'].'月'.$this->arrData['day'].'日';
+        $this->lfText(158, 288, $text, 8);  //発行日
     }
 
     private function setOrderData()

--- a/data/class/pages/admin/basis/LC_Page_Admin_Basis_Holiday.php
+++ b/data/class/pages/admin/basis/LC_Page_Admin_Basis_Holiday.php
@@ -165,7 +165,7 @@ class LC_Page_Admin_Basis_Holiday extends LC_Page_Admin_Ex
         switch ($mode) {
             case 'edit':
             case 'pre_edit':
-                $objFormParam->addParam('タイトル', 'title', SMTEXT_LEN, 'KVa', array('EXIST_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
+                $objFormParam->addParam('タイトル', 'title', STEXT_LEN, 'KVa', array('EXIST_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
                 $objFormParam->addParam('月', 'month', INT_LEN, 'n', array('SELECT_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
                 $objFormParam->addParam('日', 'day', INT_LEN, 'n', array('SELECT_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
                 $objFormParam->addParam('定休日ID', 'holiday_id', INT_LEN, 'n', array('NUM_CHECK', 'MAX_LENGTH_CHECK'));

--- a/data/class/pages/admin/basis/LC_Page_Admin_Basis_Holiday.php
+++ b/data/class/pages/admin/basis/LC_Page_Admin_Basis_Holiday.php
@@ -165,7 +165,7 @@ class LC_Page_Admin_Basis_Holiday extends LC_Page_Admin_Ex
         switch ($mode) {
             case 'edit':
             case 'pre_edit':
-                $objFormParam->addParam('タイトル', 'title', STEXT_LEN, 'KVa', array('EXIST_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
+                $objFormParam->addParam('タイトル', 'title', SMTEXT_LEN, 'KVa', array('EXIST_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
                 $objFormParam->addParam('月', 'month', INT_LEN, 'n', array('SELECT_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
                 $objFormParam->addParam('日', 'day', INT_LEN, 'n', array('SELECT_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
                 $objFormParam->addParam('定休日ID', 'holiday_id', INT_LEN, 'n', array('NUM_CHECK', 'MAX_LENGTH_CHECK'));


### PR DESCRIPTION
#40  帳票の発行日の文言が統一されていない  
帳票と帳票を生成するフォームの文言が統一されていなかったため、フォームの表記である"発行日"に統一しました。