### PR TITLE
#37 帳票の住所が長い場合に改行されずに他の項目にかぶって表示されてしまう

### DIFF
--- a/data/class/SC_Fpdf.php
+++ b/data/class/SC_Fpdf.php
@@ -135,9 +135,9 @@ class SC_Fpdf extends SC_Helper_FPDI
     private function setMessageData()
     {
         // メッセージ
-        $this->lfText(27, 70, $this->arrData['msg1'], 8);  //メッセージ1
-        $this->lfText(27, 74, $this->arrData['msg2'], 8);  //メッセージ2
-        $this->lfText(27, 78, $this->arrData['msg3'], 8);  //メッセージ3
+        $this->lfText(27, 89, $this->arrData['msg1'], 8);  //メッセージ1
+        $this->lfText(27, 92, $this->arrData['msg2'], 8);  //メッセージ2
+        $this->lfText(27, 95, $this->arrData['msg3'], 8);  //メッセージ3
         $text = '作成日: '.$this->arrData['year'].'年'.$this->arrData['month'].'月'.$this->arrData['day'].'日';
         $this->lfText(158, 288, $text, 8);  //作成日
     }
@@ -150,12 +150,40 @@ class SC_Fpdf extends SC_Helper_FPDI
 
         // 購入者情報
         $text = '〒 '.$this->arrDisp['order_zip01'].' - '.$this->arrDisp['order_zip02'];
-        $this->lfText(23, 43, $text, 10); //購入者郵便番号
-        $text = $this->arrPref[$this->arrDisp['order_pref']] . $this->arrDisp['order_addr01'];
-        $this->lfText(27, 47, $text, 10); //購入者都道府県+住所1
-        $this->lfText(27, 51, $this->arrDisp['order_addr02'], 10); //購入者住所2
+        $this->lfText(23, 43, $text, 8); //購入者郵便番号
+
+        $y = 47; // 住所1の1行目の高さ
+
+        $text = $this->arrPref[$this->arrDisp['order_pref']] . $this->arrDisp['order_addr01']; //購入者都道府県+住所1
+
+        while (mb_strwidth($text) > 68){
+            $line = mb_strimwidth($text, 0, 68); // 1行分の文字列
+            $this->lfText(27, $y, $line, 8);
+            $cut = strlen($line);
+            $text = substr($text, $cut , strlen($text) - $cut);
+            $y = $y + 3;
+        }
+        if ($text != ""){
+            $this->lfText(27, $y, $text, 8);
+            $y = $y + 3;
+        }
+
+        $text = $this->arrDisp['order_addr02']; //購入者住所2
+
+        while (mb_strwidth($text) > 68){
+            $line = mb_strimwidth($text, 0, 68); // 1行分の文字列
+            $this->lfText(27, $y, $line, 8);
+            $cut = strlen($line);
+            $text = substr($text, $cut , strlen($text) - $cut);
+            $y = $y + 3;
+        }
+        if ($text != ""){
+            $this->lfText(27, $y, $text, 8);
+            $y = $y + 3;
+        }
+
         $text = $this->arrDisp['order_name01'].'　'.$this->arrDisp['order_name02'].'　様';
-        $this->lfText(27, 59, $text, 11); //購入者氏名
+        $this->lfText(27, $y + 2, $text, 11); //購入者氏名
 
         // お届け先情報
         $this->SetFont('SJIS', '', 10);

--- a/data/class/SC_Fpdf.php
+++ b/data/class/SC_Fpdf.php
@@ -138,8 +138,8 @@ class SC_Fpdf extends SC_Helper_FPDI
         $this->lfText(27, 70, $this->arrData['msg1'], 8);  //メッセージ1
         $this->lfText(27, 74, $this->arrData['msg2'], 8);  //メッセージ2
         $this->lfText(27, 78, $this->arrData['msg3'], 8);  //メッセージ3
-        $text = '作成日: '.$this->arrData['year'].'年'.$this->arrData['month'].'月'.$this->arrData['day'].'日';
-        $this->lfText(158, 288, $text, 8);  //作成日
+        $text = '発行日: '.$this->arrData['year'].'年'.$this->arrData['month'].'月'.$this->arrData['day'].'日';
+        $this->lfText(158, 288, $text, 8);  //発行日
     }
 
     private function setOrderData()

--- a/data/class/SC_Fpdf.php
+++ b/data/class/SC_Fpdf.php
@@ -138,8 +138,8 @@ class SC_Fpdf extends SC_Helper_FPDI
         $this->lfText(27, 70, $this->arrData['msg1'], 8);  //メッセージ1
         $this->lfText(27, 74, $this->arrData['msg2'], 8);  //メッセージ2
         $this->lfText(27, 78, $this->arrData['msg3'], 8);  //メッセージ3
-        $text = '発行日: '.$this->arrData['year'].'年'.$this->arrData['month'].'月'.$this->arrData['day'].'日';
-        $this->lfText(158, 288, $text, 8);  //発行日
+        $text = '作成日: '.$this->arrData['year'].'年'.$this->arrData['month'].'月'.$this->arrData['day'].'日';
+        $this->lfText(158, 288, $text, 8);  //作成日
     }
 
     private function setOrderData()

--- a/data/class/pages/admin/basis/LC_Page_Admin_Basis_Holiday.php
+++ b/data/class/pages/admin/basis/LC_Page_Admin_Basis_Holiday.php
@@ -165,7 +165,7 @@ class LC_Page_Admin_Basis_Holiday extends LC_Page_Admin_Ex
         switch ($mode) {
             case 'edit':
             case 'pre_edit':
-                $objFormParam->addParam('タイトル', 'title', SMTEXT_LEN, 'KVa', array('EXIST_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
+                $objFormParam->addParam('タイトル', 'title', STEXT_LEN, 'KVa', array('EXIST_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
                 $objFormParam->addParam('月', 'month', INT_LEN, 'n', array('SELECT_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
                 $objFormParam->addParam('日', 'day', INT_LEN, 'n', array('SELECT_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
                 $objFormParam->addParam('定休日ID', 'holiday_id', INT_LEN, 'n', array('NUM_CHECK', 'MAX_LENGTH_CHECK'));

--- a/data/class/pages/admin/basis/LC_Page_Admin_Basis_Holiday.php
+++ b/data/class/pages/admin/basis/LC_Page_Admin_Basis_Holiday.php
@@ -165,7 +165,7 @@ class LC_Page_Admin_Basis_Holiday extends LC_Page_Admin_Ex
         switch ($mode) {
             case 'edit':
             case 'pre_edit':
-                $objFormParam->addParam('タイトル', 'title', STEXT_LEN, 'KVa', array('EXIST_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
+                $objFormParam->addParam('タイトル', 'title', SMTEXT_LEN, 'KVa', array('EXIST_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
                 $objFormParam->addParam('月', 'month', INT_LEN, 'n', array('SELECT_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
                 $objFormParam->addParam('日', 'day', INT_LEN, 'n', array('SELECT_CHECK','SPTAB_CHECK','MAX_LENGTH_CHECK'));
                 $objFormParam->addParam('定休日ID', 'holiday_id', INT_LEN, 'n', array('NUM_CHECK', 'MAX_LENGTH_CHECK'));


### PR DESCRIPTION
#37 帳票の住所が長い場合に改行されずに他の項目にかぶって表示されてしまう  
帳票の住所を1行が半角68文字を超えないように改行を施して表示するようにしました。  
最大文字数の文字列を表示できるよう、メッセージ欄を下に移動しました。