### PR TITLE
set skip_load_page_layout param to remove loading template error

### DIFF
--- a/data/class/pages/products/LC_Page_Products_Review.php
+++ b/data/class/pages/products/LC_Page_Products_Review.php
@@ -48,6 +48,7 @@ class LC_Page_Products_Review extends LC_Page_Ex
      */
     public function init()
     {
+        $this->skip_load_page_layout = true;
         parent::init();
 
         $masterData = new SC_DB_MasterData_Ex();

--- a/data/class/pages/products/LC_Page_Products_ReviewComplete.php
+++ b/data/class/pages/products/LC_Page_Products_ReviewComplete.php
@@ -39,6 +39,7 @@ class LC_Page_Products_ReviewComplete extends LC_Page_Ex
      */
     public function init()
     {
+        $this->skip_load_page_layout = true;
         parent::init();
     }
 


### PR DESCRIPTION
templateはコード内でセットしてあり、データベースにはないのでロードする処理をスキップさせる

いまは、データベースをみるのでWarningエラーが発生する