### PR TITLE
delProductKeyメソッドでキーが最大値の商品が削除できませんでした

### DIFF
--- a/data/class/SC_CartSession.php
+++ b/data/class/SC_CartSession.php
@@ -300,7 +300,7 @@ class SC_CartSession
     public function delProductKey($keyname, $val, $productTypeId)
     {
         $max = $this->getMax($productTypeId);
-        for ($i = 0; $i < $max; $i++) {
+        for ($i = 0; $i <= $max; $i++) {
             if ($this->cartSession[$productTypeId][$i][$keyname] == $val) {
                 unset($this->cartSession[$productTypeId][$i]);
             }


### PR DESCRIPTION
delProductKeyメソッドでキーが最大値の商品が削除できませんでした。