### PR TITLE
新着情報管理　既存のデータを編集する際、フォームの日付の月の項目が未選択になってしまう #136

### DIFF
--- a/data/class/pages/admin/contents/LC_Page_Admin_Contents.php
+++ b/data/class/pages/admin/contents/LC_Page_Admin_Contents.php
@@ -240,7 +240,12 @@ class LC_Page_Admin_Contents extends LC_Page_Admin_Ex
      */
     public function splitNewsDate($news_date)
     {
-        return explode('-', $news_date);
+        $arrReturn = explode('-', $news_date);
+        foreach ($arrReturn as &$part) {
+            $part = intval($part);
+        }
+
+        return $arrReturn;
     }
 
     /**


### PR DESCRIPTION
新着情報管理　既存のデータを編集する際、フォームの日付の月の項目が未選択になってしまう #136