### PR TITLE
管理画面商品規格編集不具合対応

### DIFF
--- a/data/Smarty/templates/admin/products/product_class.tpl
+++ b/data/Smarty/templates/admin/products/product_class.tpl
@@ -295,7 +295,7 @@
                         <!--{/foreach}-->
                     </td>
                     <td class="center">
-                        <!--{assign var=key value="down_filename}-->
+                        <!--{assign var=key value="down_filename"}-->
                         <!--{if $arrErr[$key][$index]}-->
                             <span class="attention"><!--{$arrErr[$key][$index]}--></span>
                         <!--{/if}-->


### PR DESCRIPTION
Smartyのタグで"が抜けていたのでエラーが発生していたので、その対応