### PR TITLE
lfRenumberのMYSQL環境でのエラー対応

### DIFF
--- a/data/class/pages/admin/products/LC_Page_Admin_Products_ProductRank.php
+++ b/data/class/pages/admin/products/LC_Page_Admin_Products_ProductRank.php
@@ -150,18 +150,17 @@ class LC_Page_Admin_Products_ProductRank extends LC_Page_Admin_Ex
                 rank =
                     (
                         SELECT COUNT(*)
-                        FROM dtb_product_categories t_in
-                        WHERE t_in.category_id = dtb_product_categories.category_id
-                            AND (
-                                t_in.rank < dtb_product_categories.rank
-                                OR (
-                                    t_in.rank = dtb_product_categories.rank
-                                    AND t_in.product_id < dtb_product_categories.product_id
-                                )
+                        FROM (SELECT product_id,rank FROM dtb_product_categories WHERE category_id = dtb_product_categories.category_id) t_in
+                        WHERE
+                            t_in.rank < dtb_product_categories.rank
+                            OR (
+                                t_in.rank = dtb_product_categories.rank
+                                AND t_in.product_id < dtb_product_categories.product_id
                             )
-                    ) + 1
+                ) + 1
             WHERE dtb_product_categories.category_id = ?
 __EOS__;
+
         $arrRet = $objQuery->query($sql, array($parent_category_id));
 
         return $arrRet;


### PR DESCRIPTION
https://xoops.ec-cube.net/modules/newbb/viewtopic.php?viewmode=thread&topic_id=19507&forum=11
の対応

PostgreSQL環境では問題は無いが、MYSQL環境の場合にADMIN_MODE有効時に使用可能な商品管理>商品並び替え内の"内部順位再割り当て"でクエリエラーが起こる問題に対応