### PR TITLE
mail()でメール送信する際に、return pathが設定されない不具合を修正

### DIFF
--- a/data/class/SC_SendMail.php
+++ b/data/class/SC_SendMail.php
@@ -357,6 +357,12 @@ class SC_SendMail
         switch ($backend) {
             case 'mail':
                 $arrParams = array();
+                $objDb = new SC_Helper_DB_Ex();
+                $objSite = $objDb->sfGetBasisData();
+                if(!empty($objSite['email04']) && strpos($objSite['email04'],"@") > 0)
+                {
+                    $arrParams[] = "-f ".$objSite['email04'];
+                }
                 break;
 
             case 'sendmail':


### PR DESCRIPTION
mail()で送る場合、headerにあっても反映されない