### PR TITLE
MySQL5.7.5 以降で `SET SESSION storage_engine = InnoDB` がエラーになるのを修正

### DIFF
--- a/data/class/db/dbfactory/SC_DB_DBFactory_MYSQL.php
+++ b/data/class/db/dbfactory/SC_DB_DBFactory_MYSQL.php
@@ -360,7 +360,11 @@ __EOS__;
      */
     public function initObjQuery(SC_Query &$objQuery)
     {
-        $objQuery->exec('SET SESSION storage_engine = InnoDB');
+        if ($objQuery->conn->getConnection()->server_version >= 50705) {
+            $objQuery->exec('SET SESSION default_storage_engine = InnoDB');
+        } else {
+            $objQuery->exec('SET SESSION storage_engine = InnoDB');
+        }
         $objQuery->exec("SET SESSION sql_mode = 'ANSI'");
     }
 }

--- a/html/install/index.php
+++ b/html/install/index.php
@@ -850,8 +850,12 @@ function lfExecuteSQL($filepath, $arrDsn, $disp_err = true)
 
             // MySQL 用の初期化
             // XXX SC_Query を使うようにすれば、この処理は不要となる
-            if ($arrDsn['phptype'] === 'mysql') {
-                $objDB->exec('SET SESSION storage_engine = InnoDB');
+            if ($arrDsn['phptype'] === 'mysqli') {
+                if ($objDB->getConnection()->server_version >= 50705) {
+                    $objDB->exec('SET SESSION defaut_storage_engine = InnoDB');
+                } else {
+                    $objDB->exec('SET SESSION storage_engine = InnoDB');
+                }
                 $objDB->exec("SET SESSION sql_mode = 'ANSI'");
             }
 


### PR DESCRIPTION
#84 の対応
`mysqli::server_version` でバージョンを取得し、5.7.5 以降は `default_storage_engine` を使用するよう修正