### PR TITLE
Travis-CI,AppVeyorがテスト通るように設定修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: php
 sudo: required
 php:
-  - 5.3.3
+#  - 5.3.3
   - 5.3
   - 5.4
   - 5.5
@@ -11,6 +11,8 @@ php:
 
 matrix:
   fast_finish: true
+
+dist: precise
 
 env:
   - DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # EC-CUBE 2.13系
 [![Build Status](https://travis-ci.org/EC-CUBE/eccube-2_13.svg)](https://travis-ci.org/EC-CUBE/eccube-2_13)
+[![Build status](https://ci.appveyor.com/api/projects/status/4k58ucq2smwc4h7n/branch/master?svg=true)](https://ci.appveyor.com/project/ECCUBE/eccube-2-13/branch/master)
 [![Coverage Status](https://coveralls.io/repos/EC-CUBE/eccube-2_13/badge.png)](https://coveralls.io/r/EC-CUBE/eccube-2_13)
 
 * * * * * * * * * * * * * * * * * * * *

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ install:
   #- set PATH=%PATH%;C:\MinGW\msys\1.0\bin;C:\MinGW\bin
   #- mingw-get install mingw-developer-toolkit
   ## Set PHP.
-  - cinst php -version 5.6.17
+  - cinst php -version 5.6.17 --allow-empty-checksums
   - SET PATH=C:\tools\php\;%PATH%
   - copy C:\tools\php\php.ini-production C:\tools\php\php.ini
   - echo date.timezone="Asia/Tokyo" >> C:\tools\php\php.ini


### PR DESCRIPTION
- AppVeyorのバッジも追加しました
- Travis-CIについては、Travis-Ci側のIssueのためPHP 5.3.3のテストが通らない。
修正されるまでPHP 5.3.3はコメントアウトする。
see https://github.com/travis-ci/travis-ci/issues/8639