### PR TITLE
インストーラで Warning が発生するのを修正

### DIFF
--- a/html/install/index.php
+++ b/html/install/index.php
@@ -43,6 +43,7 @@ define('INSTALL_LOG', './temp/install.log');
 ini_set('max_execution_time', 300);
 
 $objPage = new StdClass;
+$objPage->arrErr = array();
 $objPage->arrDB_TYPE = array(
     'pgsql' => 'PostgreSQL',
     'mysqli' => 'MySQL',


### PR DESCRIPTION
PHP7.2.x で以下の Warning が発生していたのを修正

```
Warning: count(): Parameter must be an array or an object that implements Countable
```

未定義の `$objPage->arrErr`  が `count()` に渡っていた