### PR TITLE
SC_Queryインスタンスの取得時の参照代入を廃止するよう統一

### DIFF
--- a/data/class/SC_CheckError.php
+++ b/data/class/SC_CheckError.php
@@ -1770,7 +1770,7 @@ class SC_CheckError
         $key = $value[1];
 
         $pref_id = $this->arrParam[$key];
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $exists = $objQuery->exists('mtb_pref', 'id = ?', array($pref_id));
         if (!$exists) {
             $this->arrErr[$key] = '※ ' . $disp . 'が不正な値です。<br />';

--- a/data/class/SC_Customer.php
+++ b/data/class/SC_Customer.php
@@ -44,7 +44,7 @@ class SC_Customer
         }
         // 本登録された会員のみ
         $sql = 'SELECT * FROM dtb_customer WHERE (email = ?' . $sql_mobile . ') AND del_flg = 0 AND status = 2';
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $result = $objQuery->getAll($sql, $arrValues);
         if (empty($result)) {
             return false;
@@ -82,7 +82,7 @@ class SC_Customer
         }
 
         // 携帯端末IDが一致し、本登録された会員を検索する。
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $exists = $objQuery->exists('dtb_customer', 'mobile_phone_id = ? AND del_flg = 0 AND status = 2', array($_SESSION['mobile']['phone_id']));
 
         return $exists;
@@ -110,7 +110,7 @@ class SC_Customer
 
         // 携帯端末IDが一致し、本登録された会員を検索する。
         $sql = 'SELECT * FROM dtb_customer WHERE mobile_phone_id = ? AND del_flg = 0 AND status = 2';
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         @list($data) = $objQuery->getAll($sql, array($_SESSION['mobile']['phone_id']));
 
         // パスワードが合っている場合は、会員情報をcustomer_dataに格納してtrueを返す。
@@ -139,7 +139,7 @@ class SC_Customer
             return;
         }
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $sqlval = array('mobile_phone_id' => $_SESSION['mobile']['phone_id']);
         $where = 'customer_id = ? AND del_flg = 0 AND status = 2';
         $objQuery->update('dtb_customer', $sqlval, $where, array($this->customer_data['customer_id']));
@@ -152,7 +152,7 @@ class SC_Customer
     {
         // 本登録された会員のみ
         $sql = 'SELECT * FROM dtb_customer WHERE (email = ? OR email_mobile = ?) AND del_flg = 0 AND status = 2';
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $result = $objQuery->getAll($sql, array($email, $email));
         $data = isset($result[0]) ? $result[0] : '';
         $this->customer_data = $data;
@@ -164,7 +164,7 @@ class SC_Customer
     {
         $sql = 'SELECT * FROM dtb_customer WHERE customer_id = ? AND del_flg = 0';
         $customer_id = $this->getValue('customer_id');
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrRet = $objQuery->getAll($sql, array($customer_id));
         $this->customer_data = isset($arrRet[0]) ? $arrRet[0] : '';
         $_SESSION['customer'] = $this->customer_data;
@@ -206,7 +206,7 @@ class SC_Customer
         if (isset($_SESSION['customer']['customer_id'])
             && SC_Utils_Ex::sfIsInt($_SESSION['customer']['customer_id'])
         ) {
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
             $email = $objQuery->get('email', 'dtb_customer', 'customer_id = ?', array($_SESSION['customer']['customer_id']));
             if ($email == $_SESSION['customer']['email']) {
                 // モバイルサイトの場合は携帯のメールアドレスが登録されていることもチェックする。
@@ -229,7 +229,7 @@ class SC_Customer
     {
         // ポイントはリアルタイム表示
         if ($keyname == 'point') {
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
             $point = $objQuery->get('point', 'dtb_customer', 'customer_id = ?', array($_SESSION['customer']['customer_id']));
             $_SESSION['customer']['point'] = $point;
 
@@ -302,7 +302,7 @@ class SC_Customer
     //受注関連の会員情報を更新
     public function updateOrderSummary($customer_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $col = <<< __EOS__
             SUM( payment_total) AS buy_total,

--- a/data/class/SC_Product.php
+++ b/data/class/SC_Product.php
@@ -199,7 +199,7 @@ __EOS__;
      */
     public function getDetail($product_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $from = $this->alldtlSQL();
         $where = 'product_id = ?';
@@ -396,7 +396,7 @@ __EOS__;
      */
     public function getProductsClass($productClassId)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->setWhere('product_class_id = ? AND T1.del_flg = 0');
         $arrRes = $this->getProductsClassByQuery($objQuery, $productClassId);
 
@@ -425,7 +425,7 @@ __EOS__;
         if (empty($productIds)) {
             return array();
         }
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $where = 'product_id IN (' . SC_Utils_Ex::repeatStrWithSeparator('?', count($productIds)) . ')';
         if (!$has_deleted) {
             $where .= ' AND T1.del_flg = 0';
@@ -460,7 +460,7 @@ __EOS__;
         if (empty($productIds)) {
             return array();
         }
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $cols = 'product_id, product_status_id';
         $from = 'dtb_product_status';
         $where = 'del_flg = 0 AND product_id IN (' . SC_Utils_Ex::repeatStrWithSeparator('?', count($productIds)) . ')';
@@ -489,7 +489,7 @@ __EOS__;
         $val['update_date'] = 'CURRENT_TIMESTAMP';
         $val['del_flg'] = '0';
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->delete('dtb_product_status', 'product_id = ?', array($productId));
         foreach ($productStatusIds as $productStatusId) {
             if ($productStatusId == '') continue;
@@ -539,7 +539,7 @@ __EOS__;
             return false;
         }
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->update('dtb_products_class', array(),
                           'product_class_id = ?', array($productClassId),
                           array('stock' => 'stock - ?'), array($quantity));
@@ -701,7 +701,7 @@ __EOS__;
     public function getCategoryIds($product_id, $include_hidden = false)
     {
         if ($this->isValidProductId($product_id, $include_hidden)) {
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
             $category_id = $objQuery->getCol('category_id', 'dtb_product_categories', 'product_id = ?', array($product_id));
         } else {
             // 不正な場合は、空の配列を返す。

--- a/data/class/api/SC_Api_Operation.php
+++ b/data/class/api/SC_Api_Operation.php
@@ -58,7 +58,7 @@ class SC_Api_Operation
      */
     protected function checkMemberAccount($member_id, $member_password)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         //パスワード、saltの取得
         $cols = 'password, salt';
         $table = 'dtb_member';
@@ -197,7 +197,7 @@ class SC_Api_Operation
      */
     protected function getApiSecretKey($access_key)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $secret_key = $objQuery->get('api_secret_key', 'dtb_api_account', 'api_access_key = ? and enable = 1 and del_flg = 0', array($access_key));
 
         return $secret_key;

--- a/data/class/api/SC_Api_Utils.php
+++ b/data/class/api/SC_Api_Utils.php
@@ -82,7 +82,7 @@ class SC_Api_Utils
     public function getApiConfig($operation_name)
     {
         // 設定優先度 DB > plugin default > base
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $where = 'operation_name Like ? AND del_flg = 0 AND enable = 1';
         $arrApiConfig = $objQuery->getRow('*', 'dtb_api_config', $where, array($operation_name));
         if (SC_Utils_Ex::isBlank($arrApiConfig)) {

--- a/data/class/api/operations/ItemSearch.php
+++ b/data/class/api/operations/ItemSearch.php
@@ -58,7 +58,7 @@ class API_ItemSearch extends SC_Api_Abstract_Ex
             $arrSearchCondition = $this->getSearchCondition($arrSearchData);
             $disp_number = 10;
 
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
             $objQuery->setWhere($arrSearchCondition['where_for_count']);
             $objProduct = new SC_Product_Ex();
             $linemax = $objProduct->findProductCount($objQuery, $arrSearchCondition['arrval']);
@@ -116,7 +116,7 @@ class API_ItemSearch extends SC_Api_Abstract_Ex
      */
     protected function getProductsList($searchCondition, $disp_number, $startno, $linemax, &$objProduct)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $arrOrderVal = array();
 
@@ -167,7 +167,7 @@ class API_ItemSearch extends SC_Api_Abstract_Ex
         // 表示すべきIDとそのIDの並び順を一気に取得
         $arrProductId = $objProduct->findProductIdsOrder($objQuery, array_merge($searchCondition['arrval'], $arrOrderVal));
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrProducts = $objProduct->getListByProductIds($objQuery, $arrProductId);
         // 規格を設定
         $objProduct->setProductsClassByProductIds($arrProductId);

--- a/data/class/db/SC_DB_MasterData.php
+++ b/data/class/db/SC_DB_MasterData.php
@@ -100,7 +100,7 @@ class SC_DB_MasterData
     {
         $columns = $this->getDefaultColumnName($columns);
 
-        $this->objQuery =& SC_Query_Ex::getSingletonInstance();
+        $this->objQuery = SC_Query_Ex::getSingletonInstance();
         if ($autoCommit) {
             $this->objQuery->begin();
         }
@@ -136,7 +136,7 @@ class SC_DB_MasterData
     {
         $columns = $this->getDefaultColumnName($columns);
 
-        $this->objQuery =& SC_Query_Ex::getSingletonInstance();
+        $this->objQuery = SC_Query_Ex::getSingletonInstance();
         if ($autoCommit) {
             $this->objQuery->begin();
         }
@@ -171,7 +171,7 @@ class SC_DB_MasterData
     {
         $columns = $this->getDefaultColumnName();
 
-        $this->objQuery =& SC_Query_Ex::getSingletonInstance();
+        $this->objQuery = SC_Query_Ex::getSingletonInstance();
         if ($autoCommit) {
             $this->objQuery->begin();
         }
@@ -202,7 +202,7 @@ class SC_DB_MasterData
      */
     public function deleteMasterData($name, $autoCommit = true)
     {
-        $this->objQuery =& SC_Query_Ex::getSingletonInstance();
+        $this->objQuery = SC_Query_Ex::getSingletonInstance();
         if ($autoCommit) {
             $this->objQuery->begin();
         }
@@ -308,7 +308,7 @@ class SC_DB_MasterData
     {
         $columns = $this->getDefaultColumnName($columns);
 
-        $this->objQuery =& SC_Query_Ex::getSingletonInstance();
+        $this->objQuery = SC_Query_Ex::getSingletonInstance();
         if (isset($columns[2]) && strlen($columns[2]) >= 1) {
             $this->objQuery->setOrder($columns[2]);
         }

--- a/data/class/db/dbfactory/SC_DB_DBFactory_MYSQL.php
+++ b/data/class/db/dbfactory/SC_DB_DBFactory_MYSQL.php
@@ -45,7 +45,7 @@ class SC_DB_DBFactory_MYSQL extends SC_DB_DBFactory
      */
     public function sfGetDBVersion($dsn = '')
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance($dsn);
+        $objQuery = SC_Query_Ex::getSingletonInstance($dsn);
         $val = $objQuery->getOne('select version()');
 
         return 'MySQL ' . $val;
@@ -82,7 +82,7 @@ class SC_DB_DBFactory_MYSQL extends SC_DB_DBFactory
      */
     public function getCharSet()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrRet = $objQuery->getAll("SHOW VARIABLES LIKE 'char%'");
 
         return $arrRet;
@@ -246,7 +246,7 @@ __EOS__;
      */
     public function findTableNames($expression = '')
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $sql = 'SHOW TABLES LIKE '. $objQuery->quote('%' . $expression . '%');
         $arrColList = $objQuery->getAll($sql);
         $arrColList = SC_Utils_Ex::sfSwapArray($arrColList, false);
@@ -328,7 +328,7 @@ __EOS__;
      */
     public function sfGetCreateIndexDefinition($table, $name, $definition)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrTblInfo = $objQuery->getTableInfo($table);
         foreach ($arrTblInfo as $fieldInfo) {
             if (array_key_exists($fieldInfo['name'], $definition['fields'])) {

--- a/data/class/db/dbfactory/SC_DB_DBFactory_PGSQL.php
+++ b/data/class/db/dbfactory/SC_DB_DBFactory_PGSQL.php
@@ -42,7 +42,7 @@ class SC_DB_DBFactory_PGSQL extends SC_DB_DBFactory
      */
     public function sfGetDBVersion($dsn = '')
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance($dsn);
+        $objQuery = SC_Query_Ex::getSingletonInstance($dsn);
         $val = $objQuery->getOne('select version()');
         $arrLine = explode(' ', $val);
 
@@ -228,7 +228,7 @@ __EOS__;
      */
     public function findTableNames($expression = '')
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $sql = '   SELECT c.relname AS name, '
             .  '     CASE c.relkind '
             .  "     WHEN 'r' THEN 'table' "

--- a/data/class/helper/SC_Helper_Address.php
+++ b/data/class/helper/SC_Helper_Address.php
@@ -42,7 +42,7 @@ class SC_Helper_Address
             return false;
         }
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $customer_id = $sqlval['customer_id'];
         $other_deliv_id = $sqlval['other_deliv_id'];
 
@@ -90,7 +90,7 @@ class SC_Helper_Address
             return false;
         }
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $col    = '*';
         $from   = 'dtb_other_deliv';
@@ -114,7 +114,7 @@ class SC_Helper_Address
             return false;
         }
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->setOrder('other_deliv_id DESC');
         //スマートフォン用の処理
         if ($startno != '') {
@@ -139,7 +139,7 @@ class SC_Helper_Address
             return false;
         }
 
-        $objQuery   =& SC_Query_Ex::getSingletonInstance();
+        $objQuery   = SC_Query_Ex::getSingletonInstance();
 
         $from   = 'dtb_other_deliv';
         $where  = 'customer_id = ? AND other_deliv_id = ?';

--- a/data/class/helper/SC_Helper_BestProducts.php
+++ b/data/class/helper/SC_Helper_BestProducts.php
@@ -39,7 +39,7 @@ class SC_Helper_BestProducts
      */
     public function getBestProducts($best_id, $has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = '*';
         $where = 'best_id = ?';
         if (!$has_deleted) {
@@ -59,7 +59,7 @@ class SC_Helper_BestProducts
      */
     public function getByRank($rank, $has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = '*';
         $where = 'rank = ?';
         if (!$has_deleted) {
@@ -80,7 +80,7 @@ class SC_Helper_BestProducts
      */
     public function getList($dispNumber = 0, $pageNumber = 0, $has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = '*';
         $where = '';
         if (!$has_deleted) {
@@ -108,7 +108,7 @@ class SC_Helper_BestProducts
      */
     public function saveBestProducts($sqlval)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $best_id = $sqlval['best_id'];
         $sqlval['update_date'] = 'CURRENT_TIMESTAMP';
@@ -140,7 +140,7 @@ class SC_Helper_BestProducts
      */
     public function deleteBestProducts($best_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $table = 'dtb_best_products';
         $arrVal = array('del_flg' => 1);
@@ -231,7 +231,7 @@ class SC_Helper_BestProducts
      */
     public function changeRank($best_id, $rank)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $table = 'dtb_best_products';
         $sqlval = array('rank' => $rank);

--- a/data/class/helper/SC_Helper_Bloc.php
+++ b/data/class/helper/SC_Helper_Bloc.php
@@ -45,7 +45,7 @@ class SC_Helper_Bloc
      */
     public function getBloc($bloc_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = '*';
         $where = 'bloc_id = ? AND device_type_id = ?';
         $arrRet = $objQuery->getRow($col, 'dtb_bloc', $where, array($bloc_id, $this->device_type_id));
@@ -68,7 +68,7 @@ class SC_Helper_Bloc
      */
     public function getList()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = '*';
         $where = 'device_type_id = ?';
         $table = 'dtb_bloc';
@@ -85,7 +85,7 @@ class SC_Helper_Bloc
      */
     public function getWhere($where = '', $sqlval = array())
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = '*';
         $where = 'device_type_id = ? ' . (SC_Utils_Ex::isBlank($where) ? $where : 'AND ' . $where);
         array_unshift($sqlval, $this->device_type_id);
@@ -103,7 +103,7 @@ class SC_Helper_Bloc
      */
     public function save($sqlval)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
 
         // blod_id が空の場合は新規登録
@@ -158,7 +158,7 @@ class SC_Helper_Bloc
      */
     public function delete($bloc_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
 
         $arrExists = $this->getWhere('bloc_id = ? AND deletable_flg = 1', array($bloc_id));

--- a/data/class/helper/SC_Helper_CSV.php
+++ b/data/class/helper/SC_Helper_CSV.php
@@ -68,7 +68,7 @@ class SC_Helper_CSV
      */
     public function sfDownloadCsv($csv_id, $where = '', $arrVal = array(), $order = '', $is_download = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // CSV出力タイトル行の作成
         $arrOutput = SC_Utils_Ex::sfSwapArray($this->sfGetCsvOutput($csv_id, 'status = ' . CSV_COLUMN_STATUS_FLG_ENABLE));
@@ -113,7 +113,7 @@ class SC_Helper_CSV
      */
     public function sfGetCsvOutput($csv_id = '', $where = '', $arrVal = array(), $order = 'rank, no')
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $cols = 'no, csv_id, col, disp_name, rank, status, rw_flg, mb_convert_kana_option, size_const_type, error_check_types';
         $table = 'dtb_csv';
@@ -229,7 +229,7 @@ class SC_Helper_CSV
      */
     public function sfDownloadCsvFromSql($sql, $arrVal = array(), $file_head = 'csv', $arrHeader = null, $is_download = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         if (!$is_download) {
             ob_start();

--- a/data/class/helper/SC_Helper_Category.php
+++ b/data/class/helper/SC_Helper_Category.php
@@ -50,7 +50,7 @@ class SC_Helper_Category
      */
     public function get($category_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = 'dtb_category.*, dtb_category_total_count.product_count';
         $from = 'dtb_category left join dtb_category_total_count ON dtb_category.category_id = dtb_category_total_count.category_id';
         $where = 'dtb_category.category_id = ? AND del_flg = 0';
@@ -74,7 +74,7 @@ class SC_Helper_Category
         static $arrCategory = array(), $cidIsKey = array();
 
         if (!isset($arrCategory[$this->count_check])) {
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
             $col = 'dtb_category.*, dtb_category_total_count.product_count';
             $from = 'dtb_category left join dtb_category_total_count ON dtb_category.category_id = dtb_category_total_count.category_id';
             // 登録商品数のチェック

--- a/data/class/helper/SC_Helper_Customer.php
+++ b/data/class/helper/SC_Helper_Customer.php
@@ -41,7 +41,7 @@ class SC_Helper_Customer
      */
     public function sfEditCustomerData($arrData, $customer_id = null)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
 
         $old_version_flag = false;
@@ -132,7 +132,7 @@ class SC_Helper_Customer
      */
     public function sfGetCustomerPoint($order_id, $use_point, $add_point)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $arrRet = $objQuery->select('customer_id', 'dtb_order', 'order_id = ?', array($order_id));
         $customer_id = $arrRet[0]['customer_id'];
@@ -164,7 +164,7 @@ class SC_Helper_Customer
     public function sfCheckRegisterUserFromEmail($email)
     {
         $objCustomer = new SC_Customer_Ex();
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // ログインしている場合、すでに登録している自分のemailの場合
         if ($objCustomer->isLoginSuccess(true)
@@ -212,7 +212,7 @@ class SC_Helper_Customer
      */
     public function sfCustomerEmailDuplicationCheck($customer_id, $email)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $arrResults = $objQuery->getRow('email, email_mobile',
                                         'dtb_customer', 'customer_id = ?',
@@ -235,7 +235,7 @@ class SC_Helper_Customer
      */
     public function sfGetCustomerData($customer_id, $mask_flg = true)
     {
-        $objQuery       =& SC_Query_Ex::getSingletonInstance();
+        $objQuery       = SC_Query_Ex::getSingletonInstance();
 
         // 会員情報DB取得
         $ret        = $objQuery->select('*', 'dtb_customer', 'customer_id=?', array($customer_id));
@@ -273,7 +273,7 @@ class SC_Helper_Customer
      */
     public function sfGetCustomerDataFromId($customer_id, $add_where = '', $arrAddVal = array())
     {
-        $objQuery   =& SC_Query_Ex::getSingletonInstance();
+        $objQuery   = SC_Query_Ex::getSingletonInstance();
 
         if ($add_where == '') {
             $where = 'customer_id = ?';
@@ -298,7 +298,7 @@ class SC_Helper_Customer
      */
     public function sfGetUniqSecretKey()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         do {
             $uniqid = SC_Utils_Ex::sfGetUniqRandomId('r');
@@ -318,7 +318,7 @@ class SC_Helper_Customer
      */
     public function sfGetCustomerId($uniqid, $check_status = false)
     {
-        $objQuery   =& SC_Query_Ex::getSingletonInstance();
+        $objQuery   = SC_Query_Ex::getSingletonInstance();
 
         $where      = 'secret_key = ?';
 
@@ -667,7 +667,7 @@ class SC_Helper_Customer
      */
     public function sfGetSearchData($arrParam, $limitMode = '')
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objSelect = new SC_CustomerList_Ex($arrParam, 'customer');
 
         $page_max = SC_Utils_Ex::sfGetSearchPageMax($arrParam['search_page_max']);
@@ -682,7 +682,7 @@ class SC_Helper_Customer
         $arrData = $objQuery->getAll($objSelect->getList(), $objSelect->arrVal);
 
         // 該当全体件数の取得
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $linemax = $objQuery->getOne($objSelect->getListCount(), $objSelect->arrVal);
 
         // ページ送りの取得
@@ -703,7 +703,7 @@ class SC_Helper_Customer
      */
     public function checkTempCustomer($login_email)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $where = 'email = ? AND status = 1 AND del_flg = 0';
         $exists = $objQuery->exists('dtb_customer', $where, array($login_email));

--- a/data/class/helper/SC_Helper_DB.php
+++ b/data/class/helper/SC_Helper_DB.php
@@ -62,7 +62,7 @@ class SC_Helper_DB
         $dbFactory = SC_DB_DBFactory_Ex::getInstance();
         $dsn = $dbFactory->getDSN($dsn);
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance($dsn);
+        $objQuery = SC_Query_Ex::getSingletonInstance($dsn);
 
         // テーブルが無ければエラー
         if (!in_array($tableName, $objQuery->listTables())) return false;
@@ -91,7 +91,7 @@ class SC_Helper_DB
      */
     public function sfColumnAdd($tableName, $colName, $colType)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         return $objQuery->query("ALTER TABLE $tableName ADD $colName $colType ");
     }
@@ -107,7 +107,7 @@ class SC_Helper_DB
      */
     public static function sfDataExists($tableName, $where, $arrWhereVal)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $exists = $objQuery->exists($tableName, $where, $arrWhereVal);
 
         return $exists;
@@ -127,7 +127,7 @@ class SC_Helper_DB
         static $arrData = null;
 
         if ($force || is_null($arrData)) {
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
 
             $arrData = $objQuery->getRow('*', 'dtb_baseinfo');
         }
@@ -210,7 +210,7 @@ class SC_Helper_DB
      */
     public function sfGetBasisCount()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         return $objQuery->count('dtb_baseinfo');
     }
@@ -222,7 +222,7 @@ class SC_Helper_DB
      */
     public function sfGetBasisExists()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         return $objQuery->exists('dtb_baseinfo');
     }
@@ -267,7 +267,7 @@ class SC_Helper_DB
      */
     public function sfGetRollbackPoint($order_id, $use_point, $add_point, $order_status)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrRet = $objQuery->select('customer_id', 'dtb_order', 'order_id = ?', array($order_id));
         $customer_id = $arrRet[0]['customer_id'];
         if ($customer_id != '' && $customer_id >= 1) {
@@ -301,7 +301,7 @@ class SC_Helper_DB
      */
     public function sfGetCatTree($parent_category_id, $count_check = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = '';
         $col .= ' cat.category_id,';
         $col .= ' cat.category_name,';
@@ -373,7 +373,7 @@ class SC_Helper_DB
      */
     public static function sfGetMultiCatTree($product_id, $count_check = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = '';
         $col .= ' cat.category_id,';
         $col .= ' cat.category_name,';
@@ -423,7 +423,7 @@ class SC_Helper_DB
     public function sfGetCatCombName($category_id)
     {
         // 商品が属するカテゴリIDを縦に取得
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrCatID = $this->sfGetParents('dtb_category', 'parent_category_id', 'category_id', $category_id);
         $ConbName = '';
 
@@ -449,7 +449,7 @@ class SC_Helper_DB
     public function sfGetFirstCat($category_id)
     {
         // 商品が属するカテゴリIDを縦に取得
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrRet = array();
         $arrCatID = $this->sfGetParents('dtb_category', 'parent_category_id', 'category_id', $category_id);
         $arrRet['id'] = $arrCatID[0];
@@ -474,7 +474,7 @@ class SC_Helper_DB
      */
     public function sfGetCategoryList($addwhere = '', $products_check = false, $head = CATEGORY_HEAD)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $where = 'del_flg = 0';
 
         if ($addwhere != '') {
@@ -515,7 +515,7 @@ class SC_Helper_DB
      */
     public function sfGetLevelCatList($parent_zero = true)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // カテゴリ名リストを取得
         $col = 'category_id, parent_category_id, category_name';
@@ -577,7 +577,7 @@ class SC_Helper_DB
         if ($objCategory->isValidCategoryId($category_id, $closed)) {
             $category_id = array($category_id);
         } elseif (SC_Utils_Ex::sfIsInt($product_id) && $product_id != 0 && SC_Helper_DB_Ex::sfIsRecord('dtb_products','product_id', $product_id, $status)) {
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
             $category_id = $objQuery->getCol('category_id', 'dtb_product_categories', 'product_id = ?', array($product_id));
         } else {
             // 不正な場合は、空の配列を返す。
@@ -596,7 +596,7 @@ class SC_Helper_DB
      */
     public function addProductBeforCategories($category_id, $product_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $sqlval = array('category_id' => $category_id,
                         'product_id' => $product_id);
@@ -621,7 +621,7 @@ class SC_Helper_DB
         $sqlval = array('category_id' => $category_id,
                         'product_id' => $product_id);
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // 現在の商品カテゴリを取得
         $arrCat = $objQuery->select('product_id, category_id, rank',
@@ -651,7 +651,7 @@ class SC_Helper_DB
      */
     public function removeProductByCategories($category_id, $product_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->delete('dtb_product_categories',
                           'category_id = ? AND product_id = ?', array($category_id, $product_id));
     }
@@ -665,7 +665,7 @@ class SC_Helper_DB
      */
     public function updateProductCategories($arrCategory_id, $product_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // 現在のカテゴリ情報を取得
         $arrCurrentCat = $objQuery->getCol('category_id',
@@ -701,7 +701,7 @@ class SC_Helper_DB
         $objProduct = new SC_Product_Ex();
 
         if ($objQuery == NULL) {
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
         }
 
         $is_out_trans = false;
@@ -915,7 +915,7 @@ __EOS__;
      */
     public function sfGetChildrenArraySub($table, $pid_name, $id_name, $arrPID)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $where = "$pid_name IN (" . SC_Utils_Ex::repeatStrWithSeparator('?', count($arrPID)) . ')';
 
@@ -984,7 +984,7 @@ __EOS__;
         if (SC_Utils_Ex::isBlank($child)) {
             return false;
         }
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         if (!is_array($child)) {
             $child = array($child);
         }
@@ -1021,7 +1021,7 @@ __EOS__;
      */
     public static function sfGetIDValueList($table, $keyname, $valname, $where = '', $arrVal = array())
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = "$keyname, $valname";
         $objQuery->setWhere('del_flg = 0');
         $objQuery->setOrder('rank DESC');
@@ -1048,7 +1048,7 @@ __EOS__;
      */
     public function sfRankUp($table, $colname, $id, $andwhere = '')
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
         $where = "$colname = ?";
         if ($andwhere != '') {
@@ -1100,7 +1100,7 @@ __EOS__;
      */
     public function sfRankDown($table, $colname, $id, $andwhere = '')
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
         $where = "$colname = ?";
         if ($andwhere != '') {
@@ -1152,7 +1152,7 @@ __EOS__;
      */
     public function sfMoveRank($tableName, $keyIdColumn, $keyId, $pos, $where = '')
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
 
         // 自身のランクを取得する
@@ -1259,7 +1259,7 @@ __EOS__;
      */
     public function sfDeleteRankRecord($table, $colname, $id, $andwhere = '',
                                 $delete = false) {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
         // 削除レコードのランクを取得する。
         $where = "$colname = ?";
@@ -1382,7 +1382,7 @@ __EOS__;
      */
     public static function sfIsRecord($table, $col, $arrVal, $addwhere = '')
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrCol = preg_split('/[, ]/', $col);
 
         $where = 'del_flg = 0';
@@ -1453,7 +1453,7 @@ __EOS__;
             if (SC_Utils_Ex::sfIsInt($maker_id) && $maker_id != 0 && $this->sfIsRecord('dtb_maker', 'maker_id', $maker_id)) {
                 $this->g_maker_id = array($maker_id);
             } elseif (SC_Utils_Ex::sfIsInt($product_id) && $product_id != 0 && $this->sfIsRecord('dtb_products', 'product_id', $product_id, $status)) {
-                $objQuery =& SC_Query_Ex::getSingletonInstance();
+                $objQuery = SC_Query_Ex::getSingletonInstance();
                 $maker_id = $objQuery->getCol('maker_id', 'dtb_products', 'product_id = ?', array($product_id));
                 $this->g_maker_id = $maker_id;
             } else {
@@ -1476,7 +1476,7 @@ __EOS__;
      */
     public function sfGetMakerList($addwhere = '', $products_check = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $where = 'del_flg = 0';
 
         if ($addwhere != '') {
@@ -1566,7 +1566,7 @@ __EOS__;
     public function sfExecSqlByFile($sqlFilePath)
     {
         if (file_exists($sqlFilePath)) {
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
 
             $sqls = file_get_contents($sqlFilePath);
             if ($sqls === false) trigger_error('ファイルは存在するが読み込めない', E_USER_ERROR);
@@ -1589,7 +1589,7 @@ __EOS__;
     {
         if (!SC_Utils_Ex::sfIsInt($product_id)) return false;
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $where = 'product_id = ? AND del_flg = 0 AND (classcategory_id1 != 0 OR classcategory_id2 != 0)';
         $exists = $objQuery->exists('dtb_products_class', $where, array($product_id));
 
@@ -1604,7 +1604,7 @@ __EOS__;
      */
     public static function registerBasisData($arrData)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $arrData = $objQuery->extractOnlyColsOf('dtb_baseinfo', $arrData);
 
@@ -1637,7 +1637,7 @@ __EOS__;
      */
     public function countRecords($table, $where = '', $arrval = array())
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = 'COUNT(*)';
 
         return $objQuery->get($col, $table, $where, $arrval);

--- a/data/class/helper/SC_Helper_Delivery.php
+++ b/data/class/helper/SC_Helper_Delivery.php
@@ -39,7 +39,7 @@ class SC_Helper_Delivery
      */
     public function get($deliv_id, $has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // 配送業者一覧の取得
         $col = '*';
@@ -76,7 +76,7 @@ class SC_Helper_Delivery
      */
     public function getList($product_type_id = null, $has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = '*';
         $where = '';
         $arrVal = array();
@@ -105,7 +105,7 @@ class SC_Helper_Delivery
      */
     public function save($sqlval)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
 
         // お届け時間
@@ -258,7 +258,7 @@ class SC_Helper_Delivery
         if ($arrDeliv['deliv_id'] == '') {
             $ret = $objDb->sfIsRecord('dtb_deliv', 'service_name', array($arrDeliv['service_name']));
         } else {
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
             $ret = (($objQuery->count('dtb_deliv', 'deliv_id != ? AND service_name = ? AND del_flg = 0', array($arrDeliv['deliv_id'], $arrDeliv['service_name'])) > 0) ? true : false);
         }
 
@@ -284,7 +284,7 @@ class SC_Helper_Delivery
      */
     public static function getDelivTime($deliv_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->setOrder('time_id');
         $results = $objQuery->select('time_id, deliv_time', 'dtb_delivtime', 'deliv_id = ?', array($deliv_id));
         $arrDelivTime = array();
@@ -303,7 +303,7 @@ class SC_Helper_Delivery
      */
     public static function getPayments($deliv_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->setOrder('rank');
 
         return $objQuery->getCol('payment_id', 'dtb_payment_options', 'deliv_id = ?', array($deliv_id), MDB2_FETCHMODE_ORDERED);
@@ -318,7 +318,7 @@ class SC_Helper_Delivery
      */
     public static function getDelivFee($pref_id, $deliv_id = 0)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         if (!is_array($pref_id)) {
             $pref_id = array($pref_id);
         }
@@ -347,7 +347,7 @@ __EOS__;
      */
     public static function getDelivFeeList($deliv_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->setOrder('pref');
         $col = 'fee_id, fee, pref';
         $where = 'deliv_id = ?';

--- a/data/class/helper/SC_Helper_Holiday.php
+++ b/data/class/helper/SC_Helper_Holiday.php
@@ -39,7 +39,7 @@ class SC_Helper_Holiday
      */
     public function get($holiday_id, $has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $where = 'holiday_id = ?';
         if (!$has_deleted) {
             $where .= ' AND del_flg = 0';
@@ -57,7 +57,7 @@ class SC_Helper_Holiday
      */
     public function getList($has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = 'holiday_id, title, month, day';
         $where = '';
         if (!$has_deleted) {
@@ -78,7 +78,7 @@ class SC_Helper_Holiday
      */
     public function save($sqlval)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $holiday_id = $sqlval['holiday_id'];
         $sqlval['update_date'] = 'CURRENT_TIMESTAMP';
@@ -147,7 +147,7 @@ class SC_Helper_Holiday
      */
     public function isDateExist($month, $day, $holiday_id = NULL)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $where = 'del_flg = 0 AND month = ? AND day = ?';
         $arrVal = array($month, $day);
         if (!SC_Utils_Ex::isBlank($holiday_id)) {

--- a/data/class/helper/SC_Helper_Kiyaku.php
+++ b/data/class/helper/SC_Helper_Kiyaku.php
@@ -39,7 +39,7 @@ class SC_Helper_Kiyaku
      */
     public function getKiyaku($kiyaku_id, $has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $where = 'kiyaku_id = ?';
         if (!$has_deleted) {
             $where .= ' AND del_flg = 0';
@@ -57,7 +57,7 @@ class SC_Helper_Kiyaku
      */
     public function getList($has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = 'kiyaku_id, kiyaku_title, kiyaku_text';
         $where = '';
         if (!$has_deleted) {
@@ -78,7 +78,7 @@ class SC_Helper_Kiyaku
      */
     public function saveKiyaku($sqlval)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $kiyaku_id = $sqlval['kiyaku_id'];
         $sqlval['update_date'] = 'CURRENT_TIMESTAMP';
@@ -146,7 +146,7 @@ class SC_Helper_Kiyaku
      */
     public function isTitleExist($title, $kiyaku_id = NULL)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $where  = 'del_flg = 0 AND kiyaku_title = ?';
         $arrVal = array($title);

--- a/data/class/helper/SC_Helper_Mail.php
+++ b/data/class/helper/SC_Helper_Mail.php
@@ -115,7 +115,7 @@ class SC_Helper_Mail
         $arrInfo = SC_Helper_DB_Ex::sfGetBasisData();
         $arrTplVar->arrInfo = $arrInfo;
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         if ($subject == '' && $header == '' && $footer == '') {
             // メールテンプレート情報の取得
@@ -217,7 +217,7 @@ class SC_Helper_Mail
      */
     function sfGetShippingData($order_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $objQuery->setOrder('shipping_id');
         $arrRet = $objQuery->select('*', 'dtb_shipping', 'order_id = ?', array($order_id));
@@ -317,7 +317,7 @@ class SC_Helper_Mail
         }
         $sqlval['mail_body'] = $body;
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $sqlval['send_id'] = $objQuery->nextVal('dtb_mail_history_send_id');
         $objQuery->insert('dtb_mail_history', $sqlval);
     }
@@ -328,7 +328,7 @@ class SC_Helper_Mail
         $col = 'email, mailmaga_flg, customer_id';
         $from = 'dtb_customer';
         $where = '(email = ? OR email_mobile = ?) AND status = 2 AND del_flg = 0';
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrRet = $objQuery->select($col, $from, $where, array($email));
         // 会員のメールアドレスが登録されている
         if (!empty($arrRet[0]['customer_id'])) {
@@ -417,7 +417,7 @@ class SC_Helper_Mail
     {
         // 初期化
         $where = '';
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // 条件文
         $where = 'del_flg = ?';
@@ -445,7 +445,7 @@ class SC_Helper_Mail
     {
         // 初期化
         $where = '';
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // 条件文
         $where = 'del_flg = ?';
@@ -473,7 +473,7 @@ class SC_Helper_Mail
      */
     public function sfSendMailmagazine($send_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objDb = new SC_Helper_DB_Ex();
         $objSite = $objDb->sfGetBasisData();
         $objMail = new SC_SendMail_Ex();

--- a/data/class/helper/SC_Helper_Mailtemplate.php
+++ b/data/class/helper/SC_Helper_Mailtemplate.php
@@ -39,7 +39,7 @@ class SC_Helper_Mailtemplate
      */
     public function get($template_id, $has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = '*';
         $where = 'template_id = ?';
         if (!$has_deleted) {
@@ -58,7 +58,7 @@ class SC_Helper_Mailtemplate
      */
     public function getList($has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = '*';
         $where = '';
         if (!$has_deleted) {
@@ -78,7 +78,7 @@ class SC_Helper_Mailtemplate
      */
     public function save($sqlval)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $template_id = $sqlval['template_id'];
         $sqlval['update_date'] = 'CURRENT_TIMESTAMP';

--- a/data/class/helper/SC_Helper_Maker.php
+++ b/data/class/helper/SC_Helper_Maker.php
@@ -39,7 +39,7 @@ class SC_Helper_Maker
      */
     public function getMaker($maker_id, $has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $where = 'maker_id = ?';
         if (!$has_deleted) {
             $where .= ' AND del_flg = 0';
@@ -58,7 +58,7 @@ class SC_Helper_Maker
      */
     public function getByName($name, $has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $where = 'name = ?';
         if (!$has_deleted) {
             $where .= ' AND del_flg = 0';
@@ -76,7 +76,7 @@ class SC_Helper_Maker
      */
     public function getList($has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = 'maker_id, name';
         $where = '';
         if (!$has_deleted) {
@@ -97,7 +97,7 @@ class SC_Helper_Maker
      */
     public function saveMaker($sqlval)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $maker_id = $sqlval['maker_id'];
         $sqlval['update_date'] = 'CURRENT_TIMESTAMP';

--- a/data/class/helper/SC_Helper_Mobile.php
+++ b/data/class/helper/SC_Helper_Mobile.php
@@ -135,7 +135,7 @@ class SC_Helper_Mobile
 
         $url = $matches[1];
         $time = date('Y-m-d H:i:s', time() - MOBILE_SESSION_LIFETIME);
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         foreach ($_REQUEST as $key => $value) {
             $session_id = $objQuery->get('session_id', 'dtb_mobile_ext_session_id',
@@ -320,7 +320,7 @@ class SC_Helper_Mobile
             $session_id = session_id();
         }
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // GC
         $time = date('Y-m-d H:i:s', time() - MOBILE_SESSION_LIFETIME);
@@ -363,7 +363,7 @@ class SC_Helper_Mobile
      */
     public function gfRegisterKaraMail($token, $email)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // GC
         $time = date('Y-m-d H:i:s', time() - MOBILE_SESSION_LIFETIME);
@@ -394,7 +394,7 @@ class SC_Helper_Mobile
      */
     public function gfFinishKaraMail($token)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $arrRow = $objQuery->getRow(
             'session_id, next_url, email',
@@ -433,7 +433,7 @@ class SC_Helper_Mobile
      */
     public function sfMobileSetExtSessionId($param_key, $param_value, $url)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // GC
         $time = date('Y-m-d H:i:s', time() - MOBILE_SESSION_LIFETIME);

--- a/data/class/helper/SC_Helper_News.php
+++ b/data/class/helper/SC_Helper_News.php
@@ -39,7 +39,7 @@ class SC_Helper_News
      */
     public static function getNews($news_id, $has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = '*, cast(news_date as date) as cast_news_date';
         $where = 'news_id = ?';
         if (!$has_deleted) {
@@ -60,7 +60,7 @@ class SC_Helper_News
      */
     public function getList($dispNumber = 0, $pageNumber = 0, $has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = '*, cast(news_date as date) as cast_news_date';
         $where = '';
         if (!$has_deleted) {
@@ -88,7 +88,7 @@ class SC_Helper_News
      */
     public function saveNews($sqlval)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $news_id = $sqlval['news_id'];
         $sqlval['update_date'] = 'CURRENT_TIMESTAMP';

--- a/data/class/helper/SC_Helper_PageLayout.php
+++ b/data/class/helper/SC_Helper_PageLayout.php
@@ -120,7 +120,7 @@ class SC_Helper_PageLayout
      */
     public function getPageProperties($device_type_id = DEVICE_TYPE_PC, $page_id = null, $where = '', $arrParams = array())
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $where = 'device_type_id = ? ' . (SC_Utils_Ex::isBlank($where) ? $where : 'AND ' . $where);
         if ($page_id === null) {
             $where = 'page_id <> ? AND ' . $where;
@@ -166,7 +166,7 @@ class SC_Helper_PageLayout
      */
     public function getBlocPositions($device_type_id, $page_id, $has_realpath = true)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $table = <<< __EOF__
         dtb_blocposition AS pos
@@ -209,7 +209,7 @@ __EOF__;
      */
     public function lfDelPageData($page_id, $device_type_id = DEVICE_TYPE_PC)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         // page_id が空でない場合にはdeleteを実行
         if ($page_id != '') {
             $arrPageData = $this->getPageProperties($device_type_id, $page_id);
@@ -233,7 +233,7 @@ __EOF__;
      */
     public function lfDelFile($filename, $device_type_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         /*
          * 同名ファイルの使用件数

--- a/data/class/helper/SC_Helper_Payment.php
+++ b/data/class/helper/SC_Helper_Payment.php
@@ -39,7 +39,7 @@ class SC_Helper_Payment
      */
     public function get($payment_id, $has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $where = 'payment_id = ?';
         if (!$has_deleted) {
             $where .= ' AND del_flg = 0';
@@ -57,7 +57,7 @@ class SC_Helper_Payment
      */
     public function getList($has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = 'payment_id, payment_method, payment_image, charge, rule_max, upper_rule, note, fix, charge_flg';
         $where = '';
         if (!$has_deleted) {
@@ -114,7 +114,7 @@ class SC_Helper_Payment
      */
     public function save($sqlval)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $payment_id = $sqlval['payment_id'];
         $sqlval['update_date'] = 'CURRENT_TIMESTAMP';
@@ -181,7 +181,7 @@ class SC_Helper_Payment
      */
     public static function useModule($payment_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $memo03 = $objQuery->get('memo03', 'dtb_payment', 'payment_id = ?', array($payment_id));
 
         return !SC_Utils_Ex::isBlank($memo03);

--- a/data/class/helper/SC_Helper_Purchase.php
+++ b/data/class/helper/SC_Helper_Purchase.php
@@ -62,7 +62,7 @@ class SC_Helper_Purchase
      */
     public function completeOrder($orderStatus = ORDER_NEW)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objSiteSession = new SC_SiteSession_Ex();
         $objCartSession = new SC_CartSession_Ex();
         $objCustomer = new SC_Customer_Ex();
@@ -121,7 +121,7 @@ class SC_Helper_Purchase
      */
     public function cancelOrder($order_id, $orderStatus = ORDER_CANCEL, $is_delete = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $in_transaction = $objQuery->inTransaction();
         if (!$in_transaction) {
             $objQuery->begin();
@@ -164,7 +164,7 @@ class SC_Helper_Purchase
      */
     public function rollbackOrder($order_id, $orderStatus = ORDER_CANCEL, $is_delete = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $in_transaction = $objQuery->inTransaction();
         if (!$in_transaction) {
             $objQuery->begin();
@@ -249,7 +249,7 @@ class SC_Helper_Purchase
      */
     public function getOrderTemp($uniqId)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         return $objQuery->getRow('*', 'dtb_order_temp', 'order_temp_id = ?', array($uniqId));
     }
@@ -262,7 +262,7 @@ class SC_Helper_Purchase
      */
     public function getOrderTempByOrderId($order_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         return $objQuery->getRow('*', 'dtb_order_temp', 'order_id = ?', array($order_id));
     }
@@ -283,7 +283,7 @@ class SC_Helper_Purchase
             return;
         }
         $params['device_type_id'] = SC_Display_Ex::detectDevice();
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         // 存在するカラムのみを対象とする
         $cols = $objQuery->listTableFields('dtb_order_temp');
         $sqlval = array();
@@ -663,7 +663,7 @@ class SC_Helper_Purchase
      */
     public function registerShipping($order_id, $arrParams, $convert_shipping_date = true)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $table = 'dtb_shipping';
         $where = 'order_id = ?';
         $objQuery->delete($table, $where, array($order_id));
@@ -706,7 +706,7 @@ class SC_Helper_Purchase
      */
     public function registerShipmentItem($order_id, $shipping_id, $arrParams)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $table = 'dtb_shipment_item';
         $where = 'order_id = ? AND shipping_id = ?';
         $objQuery->delete($table, $where, array($order_id, $shipping_id));
@@ -763,7 +763,7 @@ class SC_Helper_Purchase
      */
     public function registerOrderComplete($orderParams, &$objCartSession, $cartKey)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // 不要な変数を unset
         $unsets = array('mailmaga_flg', 'deliv_check', 'point_check', 'password',
@@ -910,7 +910,7 @@ class SC_Helper_Purchase
      */
     public function getOrder($order_id, $customer_id = null)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $where = 'order_id = ?';
         $arrValues = array($order_id);
         if (!SC_Utils_Ex::isBlank($customer_id)) {
@@ -930,7 +930,7 @@ class SC_Helper_Purchase
      */
     public function getOrderDetail($order_id, $has_order_status = true)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $dbFactory  = SC_DB_DBFactory_Ex::getInstance();
         $col = <<< __EOS__
             T3.product_id,
@@ -1011,7 +1011,7 @@ __EOS__;
      */
     public function getShippings($order_id, $has_items = true)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrResults = array();
         $objQuery->setOrder('shipping_id');
         $arrShippings = $objQuery->select('*', 'dtb_shipping', 'order_id = ?',
@@ -1043,7 +1043,7 @@ __EOS__;
      */
     public function getShipmentItems($order_id, $shipping_id, $has_detail = true)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objProduct = new SC_Product_Ex();
         $arrResults = array();
         $objQuery->setOrder('order_detail_id');
@@ -1113,7 +1113,7 @@ __EOS__;
      */
     public function sfUpdateOrderStatus($orderId, $newStatus = null, $newAddPoint = null, $newUsePoint = null, &$sqlval = array())
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrOrderOld = $objQuery->getRow('status, add_point, use_point, customer_id', 'dtb_order', 'order_id = ?', array($orderId));
 
         // 対応状況が変更無しの場合、DB値を引き継ぐ
@@ -1221,7 +1221,7 @@ __EOS__;
      */
     public function sfUpdateOrderNameCol($order_id, $temp_table = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         if ($temp_table) {
             $tgt_table = 'dtb_order_temp';
@@ -1356,7 +1356,7 @@ __EOS__;
      */
     public function getNextOrderID()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         return $objQuery->nextVal('dtb_order_order_id');
     }
@@ -1383,7 +1383,7 @@ __EOS__;
         $term = PENDING_ORDER_CANCEL_TIME;
         if (!SC_Utils_Ex::isBlank($term) && preg_match("/^[0-9]+$/", $term)) {
             $target_time = strtotime('-' . $term . ' sec');
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
             $arrVal = array(date('Y/m/d H:i:s', $target_time), ORDER_PENDING);
             $objQuery->begin();
             $arrOrders = $objQuery->select('order_id', 'dtb_order', 'create_date <= ? and status = ? and del_flg = 0', $arrVal);
@@ -1403,7 +1403,7 @@ __EOS__;
         $objCustomer = new SC_Customer_Ex();
         if ($objCustomer->isLoginSuccess(true)) {
             $customer_id = $objCustomer->getValue('customer_id');
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
             $arrVal = array($customer_id, ORDER_PENDING);
             $objQuery->setOrder('create_date desc');
             $objQuery->begin();
@@ -1445,7 +1445,7 @@ __EOS__;
         if (!SC_Utils_Ex::isBlank($_SESSION['order_id'])) {
             $order_id = $_SESSION['order_id'];
             unset($_SESSION['order_id']);
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
             $objQuery->begin();
             $arrOrder =  SC_Helper_Purchase_Ex::getOrder($order_id);
             if ($arrOrder['status'] == ORDER_PENDING) {

--- a/data/class/helper/SC_Helper_Session.php
+++ b/data/class/helper/SC_Helper_Session.php
@@ -66,7 +66,7 @@ class SC_Helper_Session
      */
     public function sfSessRead($id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrRet = $objQuery->select('sess_data', 'dtb_session', 'sess_id = ?', array($id));
         if (empty($arrRet)) {
             return '';
@@ -84,7 +84,7 @@ class SC_Helper_Session
      */
     public function sfSessWrite($id, $sess_data)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $exists = $objQuery->exists('dtb_session', 'sess_id = ?', array($id));
         $sqlval = array();
         if ($exists) {
@@ -116,7 +116,7 @@ class SC_Helper_Session
      */
     public function sfSessDestroy($id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->delete('dtb_session', 'sess_id = ?', array($id));
 
         return true;
@@ -132,7 +132,7 @@ class SC_Helper_Session
     public function sfSessGc($maxlifetime)
     {
         // MAX_LIFETIME以上更新されていないセッションを削除する。
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $limit = date("Y-m-d H:i:s",time() - MAX_LIFETIME);
         $where = "update_date < '". $limit . "' ";
         $objQuery->delete('dtb_session', $where);

--- a/data/class/helper/SC_Helper_TaxRule.php
+++ b/data/class/helper/SC_Helper_TaxRule.php
@@ -162,7 +162,7 @@ class SC_Helper_TaxRule
             $arrPriorityKeys = explode(',', TAX_RULE_PRIORITY);
 
             // 条件に基づいて税の設定情報を取得
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
             $table = 'dtb_tax_rule';
             $cols = '*';
 
@@ -275,7 +275,7 @@ class SC_Helper_TaxRule
         $arrValues['update_date'] = 'CURRENT_TIMESTAMP';
 
         // 新規か更新か？
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         if ($tax_rule_id == NULL && $product_id != 0 && $product_class_id != 0) {
             $where = 'product_id = ? AND product_class_id= ? AND pref_id = ? AND country_id = ?';
             $arrVal = array($product_id, $product_class_id, $pref_id, $country_id);
@@ -307,7 +307,7 @@ class SC_Helper_TaxRule
      */
     public function getTaxRuleList($has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = 'tax_rule_id, tax_rate, calc_rule, apply_date';
         $where = '';
         if (!$has_deleted) {
@@ -328,7 +328,7 @@ class SC_Helper_TaxRule
      */
     public function getTaxRuleData($tax_rule_id, $has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $where = 'tax_rule_id = ?';
         if (!$has_deleted) {
             $where .= ' AND del_flg = 0';
@@ -344,7 +344,7 @@ class SC_Helper_TaxRule
      */
     public function getTaxRuleByTime($apply_date, $has_deleted = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $where = 'apply_date = ?';
         if (!$has_deleted) {
             $where .= ' AND del_flg = 0';
@@ -362,7 +362,7 @@ class SC_Helper_TaxRule
      */
     public function deleteTaxRuleData($tax_rule_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $sqlval = array();
         $sqlval['del_flg']     = 1;

--- a/data/class/pages/admin/LC_Page_Admin_Home.php
+++ b/data/class/pages/admin/LC_Page_Admin_Home.php
@@ -132,7 +132,7 @@ class LC_Page_Admin_Home extends LC_Page_Admin_Ex
      */
     public function lfGetCustomerCnt()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = 'COUNT(customer_id)';
         $table = 'dtb_customer';
         $where = 'del_flg = 0 AND status = 2';
@@ -148,7 +148,7 @@ class LC_Page_Admin_Home extends LC_Page_Admin_Ex
      */
     public function lfGetOrderYesterday($method)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // TODO: DBFactory使わないでも共通化できそうな気もしますが
         $dbFactory = SC_DB_DBFactory_Ex::getInstance();
@@ -165,7 +165,7 @@ class LC_Page_Admin_Home extends LC_Page_Admin_Ex
      */
     public function lfGetOrderMonth($method)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $month = date('Y/m', mktime());
 
         // TODO: DBFactory使わないでも共通化できそうな気もしますが
@@ -182,7 +182,7 @@ class LC_Page_Admin_Home extends LC_Page_Admin_Ex
      */
     public function lfGetTotalCustomerPoint()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $col = 'SUM(point)';
         $where = 'del_flg = 0';
@@ -198,7 +198,7 @@ class LC_Page_Admin_Home extends LC_Page_Admin_Ex
      */
     public function lfGetReviewYesterday()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // TODO: DBFactory使わないでも共通化できそうな気もしますが
         $dbFactory = SC_DB_DBFactory_Ex::getInstance();
@@ -214,7 +214,7 @@ class LC_Page_Admin_Home extends LC_Page_Admin_Ex
      */
     public function lfGetReviewNonDisp()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $table = 'dtb_review AS A LEFT JOIN dtb_products AS B ON A.product_id = B.product_id';
         $where = 'A.del_flg = 0 AND A.status = 2 AND B.del_flg = 0';
@@ -229,7 +229,7 @@ class LC_Page_Admin_Home extends LC_Page_Admin_Ex
      */
     public function lfGetSoldOut()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $cols = 'product_id, name';
         $table = 'dtb_products';
@@ -248,7 +248,7 @@ class LC_Page_Admin_Home extends LC_Page_Admin_Ex
      */
     public function lfGetNewOrder()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $objQuery->setOrder('order_detail_id');
         $sql_product_name = $objQuery->getSql('product_name', 'dtb_order_detail', 'order_id = dtb_order.order_id');

--- a/data/class/pages/admin/LC_Page_Admin_Index.php
+++ b/data/class/pages/admin/LC_Page_Admin_Index.php
@@ -136,7 +136,7 @@ class LC_Page_Admin_Index extends LC_Page_Admin_Ex
      */
     public function lfIsLoginMember($login_id, $pass)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         //パスワード、saltの取得
         $cols = 'password, salt';
         $table = 'dtb_member';
@@ -161,7 +161,7 @@ class LC_Page_Admin_Index extends LC_Page_Admin_Ex
      */
     public function lfDoLogin($login_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         //メンバー情報取得
         $cols = 'member_id, authority, login_date, name';
         $table = 'dtb_member';
@@ -223,7 +223,7 @@ class LC_Page_Admin_Index extends LC_Page_Admin_Ex
         GC_Utils_Ex::gfPrintLog($str_log);
 
         // 最終ログイン日時更新
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $sqlval = array();
         $sqlval['login_date'] = date('Y-m-d H:i:s');
         $table = 'dtb_member';

--- a/data/class/pages/admin/basis/LC_Page_Admin_Basis_Point.php
+++ b/data/class/pages/admin/basis/LC_Page_Admin_Basis_Point.php
@@ -121,7 +121,7 @@ class LC_Page_Admin_Basis_Point extends LC_Page_Admin_Ex
         // 入力データを渡す。
         $sqlval = $post;
         $sqlval['update_date'] = 'CURRENT_TIMESTAMP';
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         // UPDATEの実行
         $objQuery->update('dtb_baseinfo', $sqlval);
     }
@@ -132,7 +132,7 @@ class LC_Page_Admin_Basis_Point extends LC_Page_Admin_Ex
         $sqlval = $post;
         $sqlval['id'] = 1;
         $sqlval['update_date'] = 'CURRENT_TIMESTAMP';
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         // INSERTの実行
         $objQuery->insert('dtb_baseinfo', $sqlval);
     }

--- a/data/class/pages/admin/basis/LC_Page_Admin_Basis_Tradelaw.php
+++ b/data/class/pages/admin/basis/LC_Page_Admin_Basis_Tradelaw.php
@@ -139,7 +139,7 @@ class LC_Page_Admin_Basis_Tradelaw extends LC_Page_Admin_Ex
     public function lfUpdateData($sqlval)
     {
         $sqlval['update_date'] = 'CURRENT_TIMESTAMP';
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         // UPDATEの実行
         $objQuery->update('dtb_baseinfo', $sqlval);
     }
@@ -147,7 +147,7 @@ class LC_Page_Admin_Basis_Tradelaw extends LC_Page_Admin_Ex
     public function lfInsertData($sqlval)
     {
         $sqlval['update_date'] = 'CURRENT_TIMESTAMP';
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         // INSERTの実行
         $objQuery->insert('dtb_baseinfo', $sqlval);
     }

--- a/data/class/pages/admin/basis/LC_Page_Admin_Basis_ZipInstall.php
+++ b/data/class/pages/admin/basis/LC_Page_Admin_Basis_ZipInstall.php
@@ -164,7 +164,7 @@ class LC_Page_Admin_Basis_ZipInstall extends LC_Page_Admin_Ex
 
     public function lfAutoCommitZip()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // DB更新
         $objQuery->begin();
@@ -180,7 +180,7 @@ class LC_Page_Admin_Basis_ZipInstall extends LC_Page_Admin_Ex
      */
     public function lfDeleteZip()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // DB
         $objQuery->delete('mtb_zip');
@@ -209,7 +209,7 @@ class LC_Page_Admin_Basis_ZipInstall extends LC_Page_Admin_Ex
      */
     public function insertMtbZip($start = 1)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $img_path = USER_URL . USER_PACKAGE_DIR . 'admin/img/basis/'; // 画像パスは admin 固定
 
@@ -334,7 +334,7 @@ class LC_Page_Admin_Basis_ZipInstall extends LC_Page_Admin_Ex
 
     public function countMtbZip()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         return $objQuery->count('mtb_zip');
     }

--- a/data/class/pages/admin/contents/LC_Page_Admin_Contents_CSV.php
+++ b/data/class/pages/admin/contents/LC_Page_Admin_Contents_CSV.php
@@ -225,7 +225,7 @@ class LC_Page_Admin_Contents_CSV extends LC_Page_Admin_Ex
      */
     public function lfUpdCsvOutput($csv_id, $arrData = array())
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         // ひとまず、全部使用しないで更新する
         $table = 'dtb_csv';
         $where = 'csv_id = ?';

--- a/data/class/pages/admin/contents/LC_Page_Admin_Contents_CsvSql.php
+++ b/data/class/pages/admin/contents/LC_Page_Admin_Contents_CsvSql.php
@@ -246,7 +246,7 @@ class LC_Page_Admin_Contents_CsvSql extends LC_Page_Admin_Ex
      */
     public function lfGetTableList()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         // 実テーブル上のカラム設定を見に行く仕様に変更 ref #476
         $arrTable = $objQuery->listTables();
         if (SC_Utils_Ex::isBlank($arrTable)) {
@@ -274,7 +274,7 @@ class LC_Page_Admin_Contents_CsvSql extends LC_Page_Admin_Ex
         if (SC_Utils_Ex::isBlank($table)) {
             return array();
         }
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         // 実テーブル上のカラム設定を見に行く仕様に変更 ref #476
         $arrColList = $objQuery->listTableFields($table);
         $arrColList= SC_Utils_Ex::sfArrCombine($arrColList, $arrColList);
@@ -291,7 +291,7 @@ class LC_Page_Admin_Contents_CsvSql extends LC_Page_Admin_Ex
      */
     public function lfGetSqlList($where = '' , $arrVal = array())
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $table = 'dtb_csv_sql';
         $objQuery->setOrder('sql_id');
 
@@ -368,7 +368,7 @@ class LC_Page_Admin_Contents_CsvSql extends LC_Page_Admin_Ex
      */
     public function lfUpdData($sql_id, $arrSqlVal)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $table = 'dtb_csv_sql';
         $arrSqlVal['update_date'] = 'CURRENT_TIMESTAMP';
         if (SC_Utils_Ex::sfIsInt($sql_id)) {
@@ -394,7 +394,7 @@ class LC_Page_Admin_Contents_CsvSql extends LC_Page_Admin_Ex
      */
     public function lfDelData($sql_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $table = 'dtb_csv_sql';
         $where = 'sql_id = ?';
         if (SC_Utils_Ex::sfIsInt($sql_id)) {

--- a/data/class/pages/admin/contents/LC_Page_Admin_Contents_Recommend.php
+++ b/data/class/pages/admin/contents/LC_Page_Admin_Contents_Recommend.php
@@ -173,7 +173,7 @@ class LC_Page_Admin_Contents_Recommend extends LC_Page_Admin_Ex
         }
 
         $objProduct = new SC_Product_Ex;
-        $objQuery = $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrProducts = $objProduct->getListByProductIds($objQuery, $product_ids);
 
         $arrReturnProducts = array();

--- a/data/class/pages/admin/contents/LC_Page_Admin_Contents_RecommendSearch.php
+++ b/data/class/pages/admin/contents/LC_Page_Admin_Contents_RecommendSearch.php
@@ -192,7 +192,7 @@ class LC_Page_Admin_Contents_RecommendSearch extends LC_Page_Admin_Ex
         $where = $whereAndBind['where'];
         $bind = $whereAndBind['bind'];
         // 検索結果対象となる商品の数を取得
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->setWhere($where);
         $linemax = $objProduct->findProductCount($objQuery, $bind);
 
@@ -209,7 +209,7 @@ class LC_Page_Admin_Contents_RecommendSearch extends LC_Page_Admin_Ex
     {
         $where = $whereAndBind['where'];
         $bind = $whereAndBind['bind'];
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->setWhere($where);
         // 取得範囲の指定(開始行番号、行数のセット)
         $objQuery->setLimitOffset($page_max, $startno);
@@ -225,7 +225,7 @@ class LC_Page_Admin_Contents_RecommendSearch extends LC_Page_Admin_Ex
      */
     public function getProductList($arrProductId, &$objProduct)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // 表示順序
         $order = 'update_date DESC, product_id DESC';

--- a/data/class/pages/admin/customer/LC_Page_Admin_Customer_Edit.php
+++ b/data/class/pages/admin/customer/LC_Page_Admin_Customer_Edit.php
@@ -241,7 +241,7 @@ class LC_Page_Admin_Customer_Edit extends LC_Page_Admin_Ex
         $arrErr = SC_Helper_Customer_Ex::sfCustomerMypageErrorCheck($objFormParam, true);
 
         // メアド重複チェック(共通ルーチンは使えない)
-        $objQuery   =& SC_Query_Ex::getSingletonInstance();
+        $objQuery   = SC_Query_Ex::getSingletonInstance();
         $col = 'email, email_mobile, customer_id';
         $table = 'dtb_customer';
         $where = 'del_flg <> 1 AND (email Like ? OR email_mobile Like ?)';
@@ -311,7 +311,7 @@ class LC_Page_Admin_Customer_Edit extends LC_Page_Admin_Ex
         if (SC_Utils_Ex::isBlank($customer_id)) {
             return array('0', array(), NULL);
         }
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $page_max = SEARCH_PMAX;
         $table = 'dtb_order';
         $where = 'customer_id = ? AND del_flg <> 1';

--- a/data/class/pages/admin/design/LC_Page_Admin_Design.php
+++ b/data/class/pages/admin/design/LC_Page_Admin_Design.php
@@ -239,7 +239,7 @@ class LC_Page_Admin_Design extends LC_Page_Admin_Ex
     public function savePreviewData($page_id, &$objLayout)
     {
         $arrPageData = $objLayout->getPageProperties(DEVICE_TYPE_PC, $page_id);
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrPageData[0]['page_id'] = 0;
         $objQuery->update('dtb_pagelayout', $arrPageData[0], 'page_id = 0 AND device_type_id = ?', array(DEVICE_TYPE_PC));
 
@@ -258,7 +258,7 @@ class LC_Page_Admin_Design extends LC_Page_Admin_Ex
         $page_id = $is_preview ? 0 : $objFormParam->getValue('page_id');
         $device_type_id = $objFormParam->getValue('device_type_id');
         $bloc_cnt = $objFormParam->getValue('bloc_cnt');
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
         $objQuery->delete('dtb_blocposition', 'page_id = ? AND device_type_id = ?',
                           array($page_id, $device_type_id));

--- a/data/class/pages/admin/design/LC_Page_Admin_Design_MainEdit.php
+++ b/data/class/pages/admin/design/LC_Page_Admin_Design_MainEdit.php
@@ -208,7 +208,7 @@ class LC_Page_Admin_Design_MainEdit extends LC_Page_Admin_Ex
         $arrParams['keyword']       = $objFormParam->getValue('keyword');
         $arrParams['meta_robots']   = $objFormParam->getValue('meta_robots');
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
 
         $page_id = $this->registerPage($arrParams, $objLayout);
@@ -257,7 +257,7 @@ class LC_Page_Admin_Design_MainEdit extends LC_Page_Admin_Ex
      */
     public function registerPage($arrParams, &$objLayout)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // ページIDが空の場合は新規登録
         $is_new = SC_Utils_Ex::isBlank($arrParams['page_id']);
@@ -334,7 +334,7 @@ class LC_Page_Admin_Design_MainEdit extends LC_Page_Admin_Ex
             $arrValues[] = $arrParams['page_id'];
         }
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $exists = $objQuery->exists('dtb_pagelayout', $where, $arrValues);
         if ($exists) {
             $objErr->arrErr['filename'] = '※ 同じURLのデータが存在しています。別のURLを入力してください。<br />';

--- a/data/class/pages/admin/design/LC_Page_Admin_Design_Template.php
+++ b/data/class/pages/admin/design/LC_Page_Admin_Design_Template.php
@@ -187,7 +187,7 @@ class LC_Page_Admin_Design_Template extends LC_Page_Admin_Ex
             // 改行、タブを1スペースに変換
             $sql = preg_replace("/[\r\n\t]/", ' ', $sql);
             $sql_split = explode(';', $sql);
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
             foreach ($sql_split as $val) {
                 if (trim($val) != '') {
                     $objQuery->query($val);
@@ -211,7 +211,7 @@ class LC_Page_Admin_Design_Template extends LC_Page_Admin_Ex
 
             return false;
         } else {
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
             $objQuery->begin();
             $objQuery->delete('dtb_templates', 'template_code = ? AND device_type_id = ?',
                               array($template_code, $device_type_id));
@@ -316,7 +316,7 @@ class LC_Page_Admin_Design_Template extends LC_Page_Admin_Ex
      */
     public function getAllTemplates($device_type_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         return $objQuery->select('*', 'dtb_templates', 'device_type_id = ?', array($device_type_id));
     }

--- a/data/class/pages/admin/design/LC_Page_Admin_Design_UpDown.php
+++ b/data/class/pages/admin/design/LC_Page_Admin_Design_UpDown.php
@@ -156,7 +156,7 @@ class LC_Page_Admin_Design_UpDown extends LC_Page_Admin_Ex
         }
 
         // DBにすでに登録されていないかチェック
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $exists = $objQuery->exists('dtb_templates', 'template_code = ?', array($template_code));
         if ($exists) {
             $arrErr['template_code'] = '※ すでに登録されているテンプレートコードです。<br/>';
@@ -198,7 +198,7 @@ class LC_Page_Admin_Design_UpDown extends LC_Page_Admin_Ex
         $template_dir = SMARTY_TEMPLATES_REALDIR . $template_code;
         $compile_dir  = DATA_REALDIR . 'Smarty/templates_c/' . $template_code;
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
 
         $arrValues = array(

--- a/data/class/pages/admin/mail/LC_Page_Admin_Mail.php
+++ b/data/class/pages/admin/mail/LC_Page_Admin_Mail.php
@@ -225,7 +225,7 @@ class LC_Page_Admin_Mail extends LC_Page_Admin_Ex
      */
     public function lfGetTemplateData(&$objFormParam, $template_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->setOrder('template_id DESC');
         $where = 'template_id = ?';
         $arrResults = $objQuery->getRow('*', 'dtb_mailmaga_template', $where, array($template_id));
@@ -240,7 +240,7 @@ class LC_Page_Admin_Mail extends LC_Page_Admin_Ex
      */
     public function lfRegisterData(&$objFormParam)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         list($linemax, $arrSendCustomer, $objNavi) = SC_Helper_Customer_Ex::sfGetSearchData($objFormParam->getHashArray(), 'All');
         $send_customer_cnt = count($arrSendCustomer);
@@ -285,7 +285,7 @@ class LC_Page_Admin_Mail extends LC_Page_Admin_Ex
      */
     public function lfGetMailQuery($send_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // 送信履歴より、送信条件確認画面
         $sql = 'SELECT search_data FROM dtb_send_history WHERE send_id = ?';

--- a/data/class/pages/admin/mail/LC_Page_Admin_Mail_History.php
+++ b/data/class/pages/admin/mail/LC_Page_Admin_Mail_History.php
@@ -95,8 +95,8 @@ class LC_Page_Admin_Mail_History extends LC_Page_Admin_Ex
             $search_pageno = 1;
         }
         //
-        $objSelect =& SC_Query_Ex::getSingletonInstance();    // 一覧データ取得用
-        $objQuery =& SC_Query_Ex::getSingletonInstance();    // 件数取得用
+        $objSelect = SC_Query_Ex::getSingletonInstance();    // 一覧データ取得用
+        $objQuery = SC_Query_Ex::getSingletonInstance();    // 件数取得用
 
         // 該当全体件数の取得
         $linemax = $objQuery->count('dtb_send_history', 'del_flg = 0');
@@ -129,7 +129,7 @@ class LC_Page_Admin_Mail_History extends LC_Page_Admin_Ex
      */
     public function lfDeleteHistory($send_id)
     {
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
             $objQuery->update('dtb_send_history',
                               array('del_flg' =>1),
                               'send_id = ?',

--- a/data/class/pages/admin/mail/LC_Page_Admin_Mail_Template.php
+++ b/data/class/pages/admin/mail/LC_Page_Admin_Mail_Template.php
@@ -91,7 +91,7 @@ class LC_Page_Admin_Mail_Template extends LC_Page_Admin_Ex
      */
     public function lfDeleteMailTemplate($template_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->update('dtb_mailmaga_template',
                           array('del_flg' =>1),
                           'template_id = ?',

--- a/data/class/pages/admin/mail/LC_Page_Admin_Mail_TemplateInput.php
+++ b/data/class/pages/admin/mail/LC_Page_Admin_Mail_TemplateInput.php
@@ -116,7 +116,7 @@ class LC_Page_Admin_Mail_TemplateInput extends LC_Page_Admin_Ex
      */
     public function lfRegistData(&$objFormParam, $template_id = null)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $sqlval = $objFormParam->getDbArray();
 
         $sqlval['creator_id'] = $_SESSION['member_id'];

--- a/data/class/pages/admin/order/LC_Page_Admin_Order.php
+++ b/data/class/pages/admin/order/LC_Page_Admin_Order.php
@@ -405,7 +405,7 @@ class LC_Page_Admin_Order extends LC_Page_Admin_Ex
      */
     public function doDelete($where, $arrParam = array())
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $sqlval['del_flg']     = 1;
         $sqlval['update_date'] = 'CURRENT_TIMESTAMP';
         $objQuery->update('dtb_order', $sqlval, $where, $arrParam);
@@ -437,7 +437,7 @@ class LC_Page_Admin_Order extends LC_Page_Admin_Ex
      */
     public function getNumberOfLines($where, $arrValues)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         return $objQuery->count('dtb_order', $where, $arrValues);
     }
@@ -454,7 +454,7 @@ class LC_Page_Admin_Order extends LC_Page_Admin_Ex
      */
     public function findOrders($where, $arrValues, $limit, $offset, $order)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         if ($limit != 0) {
             $objQuery->setLimitOffset($limit, $offset);
         }

--- a/data/class/pages/admin/order/LC_Page_Admin_Order_Edit.php
+++ b/data/class/pages/admin/order/LC_Page_Admin_Order_Edit.php
@@ -761,7 +761,7 @@ class LC_Page_Admin_Order_Edit extends LC_Page_Admin_Order_Ex
      */
     public function doRegister($order_id, &$objPurchase, &$objFormParam, &$message, &$arrValuesBefore)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrValues = $objFormParam->getDbArray();
 
         $where = 'order_id = ?';

--- a/data/class/pages/admin/order/LC_Page_Admin_Order_Mail.php
+++ b/data/class/pages/admin/order/LC_Page_Admin_Order_Mail.php
@@ -153,7 +153,7 @@ class LC_Page_Admin_Order_Mail extends LC_Page_Admin_Order_Ex
      */
     public function getMailHistory($order_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = 'send_date, subject, template_id, send_id';
         $where = 'order_id = ?';
         $objQuery->setOrder('send_date DESC');

--- a/data/class/pages/admin/order/LC_Page_Admin_Order_MailView.php
+++ b/data/class/pages/admin/order/LC_Page_Admin_Order_MailView.php
@@ -79,7 +79,7 @@ class LC_Page_Admin_Order_MailView extends LC_Page_Admin_Ex
      */
     public function getMailHistory($send_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = 'subject, mail_body';
         $where = 'send_id = ?';
         $mailHistory = $objQuery->select($col, 'dtb_mail_history', $where, array($send_id));

--- a/data/class/pages/admin/order/LC_Page_Admin_Order_ProductSelect.php
+++ b/data/class/pages/admin/order/LC_Page_Admin_Order_ProductSelect.php
@@ -132,7 +132,7 @@ class LC_Page_Admin_Order_ProductSelect extends LC_Page_Admin_Ex
      */
     public function getProductList($arrProductId, &$objProduct)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // 表示順序
         $order = 'update_date DESC, product_id DESC';
@@ -173,7 +173,7 @@ class LC_Page_Admin_Order_ProductSelect extends LC_Page_Admin_Ex
     {
         $where = $whereAndBind['where'];
         $bind = $whereAndBind['bind'];
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->setWhere($where);
         // 取得範囲の指定(開始行番号、行数のセット)
         $objQuery->setLimitOffset($page_max, $startno);
@@ -195,7 +195,7 @@ class LC_Page_Admin_Order_ProductSelect extends LC_Page_Admin_Ex
         $where = $whereAndBind['where'];
         $bind = $whereAndBind['bind'];
         // 検索結果対象となる商品の数を取得
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->setWhere($where);
         $linemax = $objProduct->findProductCount($objQuery, $bind);
 

--- a/data/class/pages/admin/order/LC_Page_Admin_Order_Status.php
+++ b/data/class/pages/admin/order/LC_Page_Admin_Order_Status.php
@@ -147,7 +147,7 @@ class LC_Page_Admin_Order_Status extends LC_Page_Admin_Ex
     // 対応状況一覧の表示
     public function lfStatusDisp($status,$pageno)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $select ='*';
         $from = 'dtb_order';
@@ -184,7 +184,7 @@ class LC_Page_Admin_Order_Status extends LC_Page_Admin_Ex
     public function lfStatusMove($statusId, $arrOrderId)
     {
         $objPurchase = new SC_Helper_Purchase_Ex();
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         if (!isset($arrOrderId) || !is_array($arrOrderId)) {
             return false;
@@ -210,7 +210,7 @@ class LC_Page_Admin_Order_Status extends LC_Page_Admin_Ex
      */
     public function lfDelete($arrOrderId)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         if (!isset($arrOrderId) || !is_array($arrOrderId)) {
             return false;

--- a/data/class/pages/admin/ownersstore/LC_Page_Admin_OwnersStore.php
+++ b/data/class/pages/admin/ownersstore/LC_Page_Admin_OwnersStore.php
@@ -339,7 +339,7 @@ class LC_Page_Admin_OwnersStore extends LC_Page_Admin_Ex
      */
     public function installPlugin($archive_file_name, $key)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
 
         // 一時展開ディレクトリにファイルがある場合は事前に削除.
@@ -766,7 +766,7 @@ class LC_Page_Admin_OwnersStore extends LC_Page_Admin_Ex
      */
     public function updatePriority($plugin_id, $priority)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         // UPDATEする値を作成する。
         $sqlval['priority'] = $priority;
         $sqlval['update_date'] = 'CURRENT_TIMESTAMP';
@@ -787,7 +787,7 @@ class LC_Page_Admin_OwnersStore extends LC_Page_Admin_Ex
     public function registerData($arrPluginInfo, $mode = 'install')
     {
         // プラグイン情報をDB登録.
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
         $arr_sqlval_plugin = array();
         $arr_sqlval_plugin['plugin_name'] = $arrPluginInfo['PLUGIN_NAME'];
@@ -950,7 +950,7 @@ class LC_Page_Admin_OwnersStore extends LC_Page_Admin_Ex
      */
     public function updatePluginEnable($plugin_id, $enable_flg)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         // UPDATEする値を作成する。
         $sqlval['enable'] = $enable_flg;
         $sqlval['update_date'] = 'CURRENT_TIMESTAMP';
@@ -971,7 +971,7 @@ class LC_Page_Admin_OwnersStore extends LC_Page_Admin_Ex
     public function deletePlugin($plugin_id, $plugin_code)
     {
         $arrErr = array();
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
 
         SC_Plugin_Util_Ex::deletePluginByPluginId($plugin_id);
@@ -1055,7 +1055,7 @@ class LC_Page_Admin_OwnersStore extends LC_Page_Admin_Ex
 
         $conflict_alert_message = '';
         $arrConflictPluginName = array();
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         foreach ($hookPoints as $hookPoint) {
             // 競合するプラグインを取得する,
             $table = 'dtb_plugin_hookpoint AS T1 LEFT JOIN dtb_plugin AS T2 ON T1.plugin_id = T2.plugin_id';
@@ -1101,7 +1101,7 @@ class LC_Page_Admin_OwnersStore extends LC_Page_Admin_Ex
      */
     public function getHookPoint($plugin_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $table = 'dtb_plugin_hookpoint';
         $where = 'plugin_id = ?';

--- a/data/class/pages/admin/ownersstore/LC_Page_Admin_OwnersStore_Log.php
+++ b/data/class/pages/admin/ownersstore/LC_Page_Admin_OwnersStore_Log.php
@@ -99,7 +99,7 @@ FROM
     ) AS modules ON dtb_module_update_logs.module_id = modules.module_id
 ORDER BY update_date DESC
 END;
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrRet = $objQuery->getAll($sql);
 
         return isset($arrRet) ? $arrRet : array();
@@ -130,7 +130,7 @@ FROM
 WHERE
     log_id = ?
 END;
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrRet = $objQuery->getAll($sql, array($log_id));
 
         return isset($arrRet[0]) ? $arrRet[0] : array();

--- a/data/class/pages/admin/ownersstore/LC_Page_Admin_OwnersStore_Settings.php
+++ b/data/class/pages/admin/ownersstore/LC_Page_Admin_OwnersStore_Settings.php
@@ -171,7 +171,7 @@ class LC_Page_Admin_OwnersStore_Settings extends LC_Page_Admin_Ex
     public function registerOwnersStoreSettings($arrSettingsData)
     {
         $table = 'dtb_ownersstore_settings';
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $exists = $objQuery->exists($table);
 
         if ($exists) {
@@ -192,7 +192,7 @@ class LC_Page_Admin_OwnersStore_Settings extends LC_Page_Admin_Ex
         $table   = 'dtb_ownersstore_settings';
         $colmuns = '*';
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrRet = $objQuery->select($colmuns, $table);
 
         if (isset($arrRet[0])) return $arrRet[0];

--- a/data/class/pages/admin/products/LC_Page_Admin_Products.php
+++ b/data/class/pages/admin/products/LC_Page_Admin_Products.php
@@ -89,7 +89,7 @@ class LC_Page_Admin_Products extends LC_Page_Admin_Ex
         $objDb = new SC_Helper_DB_Ex();
         $objFormParam = new SC_FormParam_Ex();
         $objProduct = new SC_Product_Ex();
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // パラメーター情報の初期化
         $this->lfInitParam($objFormParam);
@@ -246,7 +246,7 @@ class LC_Page_Admin_Products extends LC_Page_Admin_Ex
      */
     public function doDelete($where, $arrParam = array())
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $product_ids = $objQuery->getCol('product_id', "dtb_products", $where, $arrParam);
 
         $sqlval['del_flg']     = 1;
@@ -365,7 +365,7 @@ class LC_Page_Admin_Products extends LC_Page_Admin_Ex
      */
     public function getNumberOfLines($where, $arrValues)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         return $objQuery->count('dtb_products', $where, $arrValues);
     }
@@ -383,7 +383,7 @@ class LC_Page_Admin_Products extends LC_Page_Admin_Ex
      */
     public function findProducts($where, $arrValues, $limit, $offset, $order, &$objProduct)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // 読み込む列とテーブルの指定
         $col = 'product_id, name, main_list_image, status, product_code_min, product_code_max, price02_min, price02_max, stock_min, stock_max, stock_unlimited_min, stock_unlimited_max, update_date';

--- a/data/class/pages/admin/products/LC_Page_Admin_Products_Category.php
+++ b/data/class/pages/admin/products/LC_Page_Admin_Products_Category.php
@@ -100,7 +100,7 @@ class LC_Page_Admin_Products_Category extends LC_Page_Admin_Ex
                 // DnDしたカテゴリと移動先のセットを分解する
                 $keys = explode('-', $_POST['keySet']);
                 if ($keys[0] && $keys[1]) {
-                    $objQuery =& SC_Query_Ex::getSingletonInstance();
+                    $objQuery = SC_Query_Ex::getSingletonInstance();
                     $objQuery->begin();
 
                     // 移動したデータのrank、level、parent_category_idを取得
@@ -284,7 +284,7 @@ class LC_Page_Admin_Products_Category extends LC_Page_Admin_Ex
      */
     public function checkError(&$objFormParam, $add)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // 入力項目チェック
         $arrErr = $objFormParam->checkError();
@@ -345,7 +345,7 @@ class LC_Page_Admin_Products_Category extends LC_Page_Admin_Ex
     {
         $category_id = $objFormParam->getValue('category_id');
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
         $up_id = $this->lfGetUpRankID($objQuery, 'dtb_category', 'parent_category_id', 'category_id', $category_id);
         if ($up_id != '') {
@@ -373,7 +373,7 @@ class LC_Page_Admin_Products_Category extends LC_Page_Admin_Ex
     {
         $category_id = $objFormParam->getValue('category_id');
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
         $down_id = $this->lfGetDownRankID($objQuery, 'dtb_category', 'parent_category_id', 'category_id', $category_id);
         if ($down_id != '') {
@@ -419,7 +419,7 @@ class LC_Page_Admin_Products_Category extends LC_Page_Admin_Ex
         if (!$parent_category_id) {
             $parent_category_id = 0;
         }
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col   = 'category_id, category_name, level, rank';
         $where = 'del_flg = 0 AND parent_category_id = ?';
         $objQuery->setOption('ORDER BY rank DESC');
@@ -435,7 +435,7 @@ class LC_Page_Admin_Products_Category extends LC_Page_Admin_Ex
      */
     public function updateCategory($category_id, $arrCategory)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $arrCategory['update_date']   = 'CURRENT_TIMESTAMP';
 
@@ -453,7 +453,7 @@ class LC_Page_Admin_Products_Category extends LC_Page_Admin_Ex
      */
     public function registerCategory($arrCategory)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $parent_category_id = $arrCategory['parent_category_id'];
 
@@ -500,7 +500,7 @@ class LC_Page_Admin_Products_Category extends LC_Page_Admin_Ex
      */
     public function isOverLevel($parent_category_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $level = $objQuery->get('level', 'dtb_category', 'category_id = ?', array($parent_category_id));
 
         return $level >= LEVEL_MAX;

--- a/data/class/pages/admin/products/LC_Page_Admin_Products_Class.php
+++ b/data/class/pages/admin/products/LC_Page_Admin_Products_Class.php
@@ -149,7 +149,7 @@ class LC_Page_Admin_Products_Class extends LC_Page_Admin_Ex
      */
     public function lfGetClass()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $where = 'del_flg <> 1';
         $objQuery->setOrder('rank DESC');
@@ -166,7 +166,7 @@ class LC_Page_Admin_Products_Class extends LC_Page_Admin_Ex
      */
     public function lfGetClassName($class_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $where = 'class_id = ?';
         $class_name = $objQuery->get('name', 'dtb_class', $where, array($class_id));
 
@@ -181,7 +181,7 @@ class LC_Page_Admin_Products_Class extends LC_Page_Admin_Ex
      */
     public function lfInsertClass($arrForm)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         // INSERTする値を作成する。
         $sqlval['name'] = $arrForm['name'];
         $sqlval['creator_id'] = $_SESSION['member_id'];
@@ -203,7 +203,7 @@ class LC_Page_Admin_Products_Class extends LC_Page_Admin_Ex
      */
     public function lfUpdateClass($arrForm)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         // UPDATEする値を作成する。
         $sqlval['name'] = $arrForm['name'];
         $sqlval['update_date'] = 'CURRENT_TIMESTAMP';
@@ -223,7 +223,7 @@ class LC_Page_Admin_Products_Class extends LC_Page_Admin_Ex
     public function lfDeleteClass($class_id)
     {
         $objDb = new SC_Helper_DB_Ex();
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $ret = $objDb->sfDeleteRankRecord('dtb_class', 'class_id', $class_id, '', true);
         $where= 'class_id = ?';
@@ -240,7 +240,7 @@ class LC_Page_Admin_Products_Class extends LC_Page_Admin_Ex
      */
     public function lfCheckError(&$objFormParam)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrForm = $objFormParam->getHashArray();
         // パラメーターの基本チェック
         $arrErr = $objFormParam->checkError();

--- a/data/class/pages/admin/products/LC_Page_Admin_Products_ClassCategory.php
+++ b/data/class/pages/admin/products/LC_Page_Admin_Products_ClassCategory.php
@@ -154,7 +154,7 @@ class LC_Page_Admin_Products_ClassCategory extends LC_Page_Admin_Ex
      */
     public function lfGetClassCat($class_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $where = 'del_flg <> 1 AND class_id = ?';
         $objQuery->setOrder('rank DESC'); // XXX 降順
@@ -171,7 +171,7 @@ class LC_Page_Admin_Products_ClassCategory extends LC_Page_Admin_Ex
      */
     public function lfGetClassName($class_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $where = 'class_id = ?';
         $name = $objQuery->get('name', 'dtb_class', $where, array($class_id));
@@ -187,7 +187,7 @@ class LC_Page_Admin_Products_ClassCategory extends LC_Page_Admin_Ex
      */
     public function lfGetClassCatName($classcategory_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $where = 'classcategory_id = ?';
         $name = $objQuery->get('name', 'dtb_classcategory', $where, array($classcategory_id));
 
@@ -202,7 +202,7 @@ class LC_Page_Admin_Products_ClassCategory extends LC_Page_Admin_Ex
      */
     public function lfInsertClass($arrForm)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
         // 親規格IDの存在チェック
         $where = 'del_flg <> 1 AND class_id = ?';
@@ -232,7 +232,7 @@ class LC_Page_Admin_Products_ClassCategory extends LC_Page_Admin_Ex
      */
     public function lfUpdateClass($arrForm)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         // UPDATEする値を作成する。
         $sqlval['name'] = $arrForm['name'];
         $sqlval['update_date'] = 'CURRENT_TIMESTAMP';
@@ -251,7 +251,7 @@ class LC_Page_Admin_Products_ClassCategory extends LC_Page_Admin_Ex
      */
     public function lfCheckError(&$objFormParam)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrForm = $objFormParam->getHashArray();
         // パラメーターの基本チェック
         $arrErr = $objFormParam->checkError();

--- a/data/class/pages/admin/products/LC_Page_Admin_Products_Product.php
+++ b/data/class/pages/admin/products/LC_Page_Admin_Products_Product.php
@@ -160,7 +160,7 @@ class LC_Page_Admin_Products_Product extends LC_Page_Admin_Products_Ex
                     $product_id = $this->lfRegistProduct($objUpFile, $objDownFile, $arrForm);
 
                     // 件数カウントバッチ実行
-                    $objQuery =& SC_Query_Ex::getSingletonInstance();
+                    $objQuery = SC_Query_Ex::getSingletonInstance();
                     $objDb = new SC_Helper_DB_Ex();
                     $objDb->sfCountCategory($objQuery);
                     $objDb->sfCountMaker($objQuery);
@@ -829,7 +829,7 @@ class LC_Page_Admin_Products_Product extends LC_Page_Admin_Products_Ex
         }
         $where .= ')';
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $exists = $objQuery->exists('dtb_products', $where, $sqlval);
 
         return $exists;
@@ -843,7 +843,7 @@ class LC_Page_Admin_Products_Product extends LC_Page_Admin_Products_Ex
      */
     public function lfGetProductData_FromDB($product_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrProduct = array();
 
         // 商品データ取得
@@ -907,7 +907,7 @@ __EOF__;
      */
     public function lfGetRecommendProductsData_FromDB($product_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrRecommendProducts = array();
 
         $col = 'recommend_product_id,';
@@ -997,7 +997,7 @@ __EOF__;
      */
     public function lfRegistProduct(&$objUpFile, &$objDownFile, $arrList)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objDb = new SC_Helper_DB_Ex();
 
         // 配列の添字を定義
@@ -1073,7 +1073,7 @@ __EOF__;
                     $arrProductsClass = $objQuery->select($col, $table, $where, array($arrList['copy_product_id']));
 
                     // 規格データ登録
-                    $objQuery =& SC_Query_Ex::getSingletonInstance();
+                    $objQuery = SC_Query_Ex::getSingletonInstance();
                     foreach ($arrProductsClass as $arrData) {
                         $sqlval = $arrData;
                         $sqlval['product_class_id'] = $objQuery->nextVal('dtb_products_class_product_class_id');
@@ -1152,7 +1152,7 @@ __EOF__;
      */
     public function lfInsertDummyProductClass($arrList)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objDb = new SC_Helper_DB_Ex();
 
         // 配列の添字を定義
@@ -1186,7 +1186,7 @@ __EOF__;
      */
     public function lfUpdateProductClass($arrList)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $sqlval = array();
 
         $sqlval['deliv_fee'] = $arrList['deliv_fee'];

--- a/data/class/pages/admin/products/LC_Page_Admin_Products_ProductClass.php
+++ b/data/class/pages/admin/products/LC_Page_Admin_Products_ProductClass.php
@@ -216,7 +216,7 @@ class LC_Page_Admin_Products_ProductClass extends LC_Page_Admin_Ex
      */
     public function registerProductClass($arrList, $product_id, $total)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objDb = new SC_Helper_DB_Ex();
 
         $objQuery->begin();
@@ -538,7 +538,7 @@ class LC_Page_Admin_Products_ProductClass extends LC_Page_Admin_Ex
      */
     public function doDelete($product_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $objQuery->begin();
 
@@ -673,7 +673,7 @@ class LC_Page_Admin_Products_ProductClass extends LC_Page_Admin_Ex
      */
     public function getAllClassCategory($class_id1, $class_id2 = null)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $col = <<< __EOF__
             T1.class_id AS class_id1,
@@ -715,7 +715,7 @@ __EOF__;
      */
     public function getProductName($product_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         return $objQuery->get('name', 'dtb_products', 'product_id = ?', array($product_id));
     }
@@ -755,7 +755,7 @@ __EOF__;
      */
     public function getProductsClass($product_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = 'product_code, price01, price02, stock, stock_unlimited, sale_limit, deliv_fee, point_rate';
         $where = 'product_id = ? AND classcategory_id1 = 0 AND classcategory_id2 = 0';
 

--- a/data/class/pages/admin/products/LC_Page_Admin_Products_ProductRank.php
+++ b/data/class/pages/admin/products/LC_Page_Admin_Products_ProductRank.php
@@ -108,7 +108,7 @@ class LC_Page_Admin_Products_ProductRank extends LC_Page_Admin_Ex
     public function lfGetProduct($category_id)
     {
         // FIXME SC_Product クラスを使用した実装
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = 'alldtl.product_id, name, main_list_image, product_code_min, product_code_max, status';
         $objProduct = new SC_Product();
         $table = $objProduct->alldtlSQL();
@@ -142,7 +142,7 @@ class LC_Page_Admin_Products_ProductRank extends LC_Page_Admin_Ex
      */
     public function lfRenumber($parent_category_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $sql = <<< __EOS__
             UPDATE dtb_product_categories

--- a/data/class/pages/admin/products/LC_Page_Admin_Products_ProductSelect.php
+++ b/data/class/pages/admin/products/LC_Page_Admin_Products_ProductSelect.php
@@ -139,7 +139,7 @@ class LC_Page_Admin_Products_ProductSelect extends LC_Page_Admin_Ex
 
         $order = 'update_date DESC, product_id DESC ';
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         // 行数の取得
         $linemax = $objQuery->count('dtb_products', $where, $arrWhereVal);
         $this->tpl_linemax = $linemax;              // 何件が該当しました。表示用

--- a/data/class/pages/admin/products/LC_Page_Admin_Products_Review.php
+++ b/data/class/pages/admin/products/LC_Page_Admin_Products_Review.php
@@ -167,7 +167,7 @@ class LC_Page_Admin_Products_Review extends LC_Page_Admin_Ex
      */
     public function lfDeleteReview($review_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $sqlval['del_flg'] = 1;
         $objQuery->update('dtb_review', $sqlval, 'review_id = ?', array($review_id));
     }
@@ -340,7 +340,7 @@ class LC_Page_Admin_Products_Review extends LC_Page_Admin_Ex
      */
     public function lfGetReview($arrForm, $where, $arrWhereVal)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // ページ送りの処理
         $page_max = SC_Utils_Ex::sfGetSearchPageMax($arrForm['search_page_max']);

--- a/data/class/pages/admin/products/LC_Page_Admin_Products_ReviewEdit.php
+++ b/data/class/pages/admin/products/LC_Page_Admin_Products_ReviewEdit.php
@@ -133,7 +133,7 @@ class LC_Page_Admin_Products_ReviewEdit extends LC_Page_Admin_Products_Review
      */
     public function lfGetReviewData($review_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $select='review_id, A.product_id, reviewer_name, sex, recommend_level, ';
         $select.='reviewer_url, title, comment, A.status, A.create_date, A.update_date, name';
         $from = 'dtb_review AS A LEFT JOIN dtb_products AS B ON A.product_id = B.product_id ';
@@ -155,7 +155,7 @@ class LC_Page_Admin_Products_ReviewEdit extends LC_Page_Admin_Products_Review
      */
     public function lfRegistReviewData($review_id, &$objFormParam)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrValues = $objFormParam->getDbArray();
         $arrValues['update_date'] = 'CURRENT_TIMESTAMP';
         $objQuery->update('dtb_review', $arrValues, 'review_id = ?', array($review_id));

--- a/data/class/pages/admin/products/LC_Page_Admin_Products_UploadCSV.php
+++ b/data/class/pages/admin/products/LC_Page_Admin_Products_UploadCSV.php
@@ -272,7 +272,7 @@ class LC_Page_Admin_Products_UploadCSV extends LC_Page_Admin_Ex
         // 登録フォーム カラム情報
         $this->arrFormKeyList = $objFormParam->getKeyList();
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
 
         // CSVからの読み込み、入力エラーチェック
@@ -388,7 +388,7 @@ class LC_Page_Admin_Products_UploadCSV extends LC_Page_Admin_Ex
      */
     public function lfInitTableInfo()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $this->arrProductColumn = $objQuery->listTableFields('dtb_products');
         $this->arrProductClassColumn = $objQuery->listTableFields('dtb_products_class');
     }
@@ -862,7 +862,7 @@ class LC_Page_Admin_Products_UploadCSV extends LC_Page_Admin_Ex
         $count = count($arrItems);
         $where = $tblkey .' IN (' . SC_Utils_Ex::repeatStrWithSeparator('?', $count) . ')';
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $db_count = $objQuery->count($table, $where, $arrItems);
         if ($count != $db_count) {
             return false;

--- a/data/class/pages/admin/products/LC_Page_Admin_Products_UploadCSVCategory.php
+++ b/data/class/pages/admin/products/LC_Page_Admin_Products_UploadCSVCategory.php
@@ -193,7 +193,7 @@ class LC_Page_Admin_Products_UploadCSVCategory extends LC_Page_Admin_Ex
         // 行数
         $line_count = 0;
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
 
         $errFlag = false;
@@ -347,7 +347,7 @@ class LC_Page_Admin_Products_UploadCSVCategory extends LC_Page_Admin_Ex
      */
     public function lfInitTableInfo()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $this->arrRegistColumn = $objQuery->listTableFields('dtb_category');
     }
 
@@ -456,7 +456,7 @@ class LC_Page_Admin_Products_UploadCSVCategory extends LC_Page_Admin_Ex
      */
     public function lfCheckErrorDetail($item, $arrErr)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         /*
         // カテゴリIDの存在チェック
         if (!$this->lfIsDbRecord('dtb_category', 'category_id', $item)) {
@@ -527,7 +527,7 @@ class LC_Page_Admin_Products_UploadCSVCategory extends LC_Page_Admin_Ex
      */
     public function registerCategory($parent_category_id, $category_name, $creator_id, $category_id = null)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $rank = null;
         if ($parent_category_id == 0) {

--- a/data/class/pages/admin/system/LC_Page_Admin_System.php
+++ b/data/class/pages/admin/system/LC_Page_Admin_System.php
@@ -104,7 +104,7 @@ class LC_Page_Admin_System extends LC_Page_Admin_Ex
      */
     public function getMemberCount($where)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $table = 'dtb_member';
 
         return $objQuery->count($table, $where);
@@ -122,7 +122,7 @@ class LC_Page_Admin_System extends LC_Page_Admin_Ex
         $col = 'member_id,name,department,login_id,authority,rank,work';
         $from = 'dtb_member';
         $where = 'del_flg <> 1 AND member_id <> ?';
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->setOrder('rank DESC');
         $objQuery->setLimitOffset(MEMBER_PMAX, $startno);
         $arrMemberData = $objQuery->select($col, $from, $where, array(ADMIN_ID));

--- a/data/class/pages/admin/system/LC_Page_Admin_System_Bkup.php
+++ b/data/class/pages/admin/system/LC_Page_Admin_System_Bkup.php
@@ -271,7 +271,7 @@ class LC_Page_Admin_System_Bkup extends LC_Page_Admin_Ex
      */
     public function lfCreateBkupData($bkup_name, $work_dir)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $csv_autoinc = '';
         $arrData = array();
 
@@ -372,7 +372,7 @@ class LC_Page_Admin_System_Bkup extends LC_Page_Admin_Ex
      */
     public function lfGetAutoIncrement()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrSequences = $objQuery->listSequences();
 
         foreach ($arrSequences as $name) {
@@ -395,7 +395,7 @@ class LC_Page_Admin_System_Bkup extends LC_Page_Admin_Ex
     // バックアップテーブルにデータを更新する
     public function lfUpdBkupData($data)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $arrVal = array();
         $arrVal['bkup_name'] = $data['bkup_name'];
@@ -410,7 +410,7 @@ class LC_Page_Admin_System_Bkup extends LC_Page_Admin_Ex
      */
     public function lfGetBkupData($sql_option = '', $filter_bkup_name = '')
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // テーブルから取得
         $arrVal = array();
@@ -464,7 +464,7 @@ class LC_Page_Admin_System_Bkup extends LC_Page_Admin_Ex
      */
     public function lfRestore($bkup_name, $bkup_dir, $bkup_ext, $mode)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $bkup_filepath = $bkup_dir . $bkup_name . $bkup_ext;
         $work_dir = $bkup_dir . $bkup_name . '/';
@@ -609,7 +609,7 @@ class LC_Page_Admin_System_Bkup extends LC_Page_Admin_Ex
     // 選択したバックアップをDBから削除
     public function lfDeleteBackUp(&$arrForm, $bkup_dir, $bkup_ext)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $del_file = $bkup_dir.$arrForm['list_name'] . $bkup_ext;
         // ファイルの削除

--- a/data/class/pages/admin/system/LC_Page_Admin_System_Delete.php
+++ b/data/class/pages/admin/system/LC_Page_Admin_System_Delete.php
@@ -106,7 +106,7 @@ class LC_Page_Admin_System_Delete extends LC_Page_Admin_Ex
      */
     public function deleteMember($id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
 
         $this->renumberRank($objQuery, $id);

--- a/data/class/pages/admin/system/LC_Page_Admin_System_Editdb.php
+++ b/data/class/pages/admin/system/LC_Page_Admin_System_Editdb.php
@@ -107,7 +107,7 @@ class LC_Page_Admin_System_Editdb extends LC_Page_Admin_Ex
      */
     public function lfDoChange(&$objFormParam)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrTarget = $this->lfGetTargetData($objFormParam);
         $message = '';
         if (is_array($arrTarget) && count($arrTarget) == 0) {
@@ -138,7 +138,7 @@ class LC_Page_Admin_System_Editdb extends LC_Page_Admin_Ex
      */
     public function lfGetTargetData(&$objFormParam)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrIndexFlag    = $objFormParam->getValue('indexflag');
         $arrIndexFlagNew = $objFormParam->getValue('indexflag_new');
         $arrTableName    = $objFormParam->getValue('table_name');
@@ -185,7 +185,7 @@ class LC_Page_Admin_System_Editdb extends LC_Page_Admin_Ex
     public function lfGetIndexList()
     {
         // データベースからインデックス設定一覧を取得する
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->setOrder('table_name, column_name');
         $arrIndexList = $objQuery->select('table_name , column_name , recommend_flg, recommend_comment', 'dtb_index_list');
 

--- a/data/class/pages/admin/system/LC_Page_Admin_System_Input.php
+++ b/data/class/pages/admin/system/LC_Page_Admin_System_Input.php
@@ -263,7 +263,7 @@ class LC_Page_Admin_System_Input extends LC_Page_Admin_Ex
         $columns = 'name,department,login_id,authority, work';
         $where   = 'member_id = ?';
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         return $objQuery->getRow($columns, $table, $where, array($id));
     }
@@ -277,7 +277,7 @@ class LC_Page_Admin_System_Input extends LC_Page_Admin_Ex
      */
     public function memberDataExists($where, $val)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $table = 'dtb_member';
 
@@ -316,7 +316,7 @@ class LC_Page_Admin_System_Input extends LC_Page_Admin_Ex
      */
     public function insertMemberData($arrMemberData)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // INSERTする値を作成する.
         $salt                  = SC_Utils_Ex::sfGetRandomString(10);
@@ -347,7 +347,7 @@ class LC_Page_Admin_System_Input extends LC_Page_Admin_Ex
      */
     public function updateMemberData($member_id, $arrMemberData)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // Updateする値を作成する.
         $sqlVal = array();

--- a/data/class/pages/admin/system/LC_Page_Admin_System_Masterdata.php
+++ b/data/class/pages/admin/system/LC_Page_Admin_System_Masterdata.php
@@ -184,7 +184,7 @@ class LC_Page_Admin_System_Masterdata extends LC_Page_Admin_Ex
         }
 
         // マスターデータを更新
-        $masterData->objQuery =& SC_Query_Ex::getSingletonInstance();
+        $masterData->objQuery = SC_Query_Ex::getSingletonInstance();
         $masterData->objQuery->begin();
         $masterData->deleteMasterData($master_data_name, false);
         // TODO カラム名はメタデータから取得した方が良い

--- a/data/class/pages/admin/system/LC_Page_Admin_System_Rank.php
+++ b/data/class/pages/admin/system/LC_Page_Admin_System_Rank.php
@@ -102,7 +102,7 @@ class LC_Page_Admin_System_Rank extends LC_Page_Admin_Ex
     // ランキングを上げる。
     public function lfRunkUp($id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // 自身のランクを取得する。
         $rank = $objQuery->getOne('SELECT rank FROM dtb_member WHERE member_id = ?', array($id));
@@ -133,7 +133,7 @@ class LC_Page_Admin_System_Rank extends LC_Page_Admin_Ex
     // ランキングを下げる。
     public function lfRunkDown($id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // 自身のランクを取得する。
         $rank = $objQuery->getOne('SELECT rank FROM dtb_member WHERE member_id = ?', array($id));

--- a/data/class/pages/cart/LC_Page_Cart.php
+++ b/data/class/pages/cart/LC_Page_Cart.php
@@ -262,7 +262,7 @@ class LC_Page_Cart extends LC_Page_Ex
     {
         $sqlval['order_temp_id'] = $uniqid;
         $where = 'order_temp_id = ?';
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $res = $objQuery->update('dtb_order_temp', $sqlval, $where, array($pre_uniqid));
         if ($res != 1) {
             return false;

--- a/data/class/pages/forgot/LC_Page_Forgot.php
+++ b/data/class/pages/forgot/LC_Page_Forgot.php
@@ -146,7 +146,7 @@ class LC_Page_Forgot extends LC_Page_Ex
     public function lfCheckForgotMail(&$arrForm, &$arrReminder)
     {
         $errmsg = NULL;
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $where = '(email = ? OR email_mobile = ?) AND name01 = ? AND name02 = ? AND del_flg = 0';
         $arrVal = array($arrForm['email'], $arrForm['email'], $arrForm['name01'], $arrForm['name02']);
         $result = $objQuery->select('reminder, status', 'dtb_customer', $where, $arrVal);
@@ -196,7 +196,7 @@ class LC_Page_Forgot extends LC_Page_Ex
     public function lfCheckForgotSecret(&$arrForm, &$arrReminder)
     {
         $errmsg = '';
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $cols = 'customer_id, reminder, reminder_answer, salt';
         $table = 'dtb_customer';
         $where = '(email = ? OR email_mobile = ?)'

--- a/data/class/pages/frontparts/bloc/LC_Page_FrontParts_Bloc_Category.php
+++ b/data/class/pages/frontparts/bloc/LC_Page_FrontParts_Bloc_Category.php
@@ -136,7 +136,7 @@ class LC_Page_FrontParts_Bloc_Category extends LC_Page_FrontParts_Bloc_Ex
      */
     public function lfGetMainCat($count_check = false)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = '*';
         $from = 'dtb_category left join dtb_category_total_count ON dtb_category.category_id = dtb_category_total_count.category_id';
         // メインカテゴリとその直下のカテゴリを取得する。

--- a/data/class/pages/frontparts/bloc/LC_Page_FrontParts_Bloc_Recommend.php
+++ b/data/class/pages/frontparts/bloc/LC_Page_FrontParts_Bloc_Recommend.php
@@ -83,7 +83,7 @@ class LC_Page_FrontParts_Bloc_Recommend extends LC_Page_FrontParts_Bloc_Ex
         $response = array();
         if (count($arrRecommends) > 0) {
             // 商品一覧を取得
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
             $objProduct = new SC_Product_Ex();
             // where条件生成&セット
             $arrProductId = array();

--- a/data/class/pages/mypage/LC_Page_Mypage_DownLoad.php
+++ b/data/class/pages/mypage/LC_Page_Mypage_DownLoad.php
@@ -162,7 +162,7 @@ class LC_Page_Mypage_DownLoad extends LC_Page_Ex
      */
     public function lfGetRealFileName($customer_id, $order_id, $product_class_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = <<< __EOS__
             pc.down_realfilename AS down_realfilename,
             pc.down_filename AS down_filename

--- a/data/class/pages/mypage/LC_Page_Mypage_Favorite.php
+++ b/data/class/pages/mypage/LC_Page_Mypage_Favorite.php
@@ -126,7 +126,7 @@ class LC_Page_Mypage_Favorite extends LC_Page_AbstractMypage_Ex
         }
         $arrProductId  = $objQuery->getCol('f.product_id', 'dtb_customer_favorite_products f inner join dtb_products p using (product_id)', $where, array($customer_id));
 
-        $objQuery       =& SC_Query_Ex::getSingletonInstance();
+        $objQuery       = SC_Query_Ex::getSingletonInstance();
         $objQuery->setWhere($this->lfMakeWhere('alldtl.', $arrProductId));
         $linemax        = $objProduct->findProductCount($objQuery);
 
@@ -137,7 +137,7 @@ class LC_Page_Mypage_Favorite extends LC_Page_AbstractMypage_Ex
         $this->tpl_strnavi = $objNavi->strnavi; // 表示文字列
         $startno        = $objNavi->start_row;
 
-        $objQuery       =& SC_Query_Ex::getSingletonInstance();
+        $objQuery       = SC_Query_Ex::getSingletonInstance();
         //$objQuery->setLimitOffset(SEARCH_PMAX, $startno);
         // 取得範囲の指定(開始行番号、行数のセット)
         $arrProductId  = array_slice($arrProductId, $startno, SEARCH_PMAX);
@@ -189,7 +189,7 @@ class LC_Page_Mypage_Favorite extends LC_Page_AbstractMypage_Ex
      */
     public function lfDeleteFavoriteProduct($customer_id, $product_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $exists = $objQuery->exists('dtb_customer_favorite_products', 'customer_id = ? AND product_id = ?', array($customer_id, $product_id));
 

--- a/data/class/pages/mypage/LC_Page_Mypage_History.php
+++ b/data/class/pages/mypage/LC_Page_Mypage_History.php
@@ -138,7 +138,7 @@ class LC_Page_Mypage_History extends LC_Page_AbstractMypage_Ex
      */
     public function lfGetMailHistory($order_id)
     {
-        $objQuery   =& SC_Query_Ex::getSingletonInstance();
+        $objQuery   = SC_Query_Ex::getSingletonInstance();
         $col        = 'send_date, subject, template_id, send_id';
         $where      = 'order_id = ?';
         $objQuery->setOrder('send_date DESC');
@@ -181,7 +181,7 @@ class LC_Page_Mypage_History extends LC_Page_AbstractMypage_Ex
     {
         $i = 0;
         foreach ($arrOrderDetails as $arrOrderDetail) {
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
             $arrProduct = $objQuery->select('main_list_image', 'dtb_products', 'product_id = ?', array($arrOrderDetail['product_id']));
             $arrOrderDetails[$i]['main_list_image'] = $arrProduct[0]['main_list_image'];
             $i++;
@@ -201,7 +201,7 @@ class LC_Page_Mypage_History extends LC_Page_AbstractMypage_Ex
         $objHelperMobile = new SC_Helper_Mobile_Ex();
         $i = 0;
         foreach ($arrOrderDetails as $arrOrderDetail) {
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
             $arrProduct = $objQuery->select('down_realfilename,down_filename', 'dtb_products_class', 'product_id = ? AND product_class_id = ?', array($arrOrderDetail['product_id'],$arrOrderDetail['product_class_id']));
             $arrOrderDetails[$i]['mime_type'] = $objHelperMobile->getMimeType($arrProduct[0]['down_realfilename']);
             $arrOrderDetails[$i]['down_filename'] = $arrProduct[0]['down_filename'];

--- a/data/class/pages/products/LC_Page_Products_Detail.php
+++ b/data/class/pages/products/LC_Page_Products_Detail.php
@@ -473,7 +473,7 @@ class LC_Page_Products_Detail extends LC_Page_Ex
     public function lfPreGetRecommendProducts($product_id)
     {
         $objProduct = new SC_Product_Ex();
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $objQuery->setOrder('rank DESC');
         $arrRecommendData = $objQuery->select('recommend_product_id, comment', 'dtb_recommend_products as t1 left join dtb_products as t2 on t1.recommend_product_id = t2.product_id', 't1.product_id = ? and t2.del_flg = 0 and t2.status = 1', array($product_id));
@@ -483,7 +483,7 @@ class LC_Page_Products_Detail extends LC_Page_Ex
             $recommendProductIds[] = $recommend['recommend_product_id'];
         }
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrProducts = $objProduct->getListByProductIds($objQuery, $recommendProductIds);
 
         foreach ($arrRecommendData as $key => $arrRow) {
@@ -540,7 +540,7 @@ class LC_Page_Products_Detail extends LC_Page_Ex
      */
     public function lfGetReviewData($product_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         //商品ごとのレビュー情報を取得する
         $col = 'create_date, reviewer_url, reviewer_name, recommend_level, title, comment';
         $from = 'dtb_review';
@@ -591,7 +591,7 @@ class LC_Page_Products_Detail extends LC_Page_Ex
 
             return false;
         } else {
-            $objQuery =& SC_Query_Ex::getSingletonInstance();
+            $objQuery = SC_Query_Ex::getSingletonInstance();
             $exists = $objQuery->exists('dtb_customer_favorite_products', 'customer_id = ? AND product_id = ?', array($customer_id, $favorite_product_id));
 
             if (!$exists) {

--- a/data/class/pages/products/LC_Page_Products_List.php
+++ b/data/class/pages/products/LC_Page_Products_List.php
@@ -208,7 +208,7 @@ class LC_Page_Products_List extends LC_Page_Ex
      */
     public function lfGetProductsList($searchCondition, $disp_number, $startno, &$objProduct)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $arrOrderVal = array();
 
@@ -246,7 +246,7 @@ class LC_Page_Products_List extends LC_Page_Ex
         // 表示すべきIDとそのIDの並び順を一気に取得
         $arrProductId = $objProduct->findProductIdsOrder($objQuery, array_merge($searchCondition['arrval'], $arrOrderVal));
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrProducts = $objProduct->getListByProductIds($objQuery, $arrProductId);
 
         // 規格を設定
@@ -319,7 +319,7 @@ class LC_Page_Products_List extends LC_Page_Ex
      */
     public function lfGetSearchConditionDisp($arrSearchData)
     {
-        $objQuery   =& SC_Query_Ex::getSingletonInstance();
+        $objQuery   = SC_Query_Ex::getSingletonInstance();
         $arrSearch  = array('category' => '指定なし', 'maker' => '指定なし', 'name' => '指定なし');
         // カテゴリ検索条件
         if ($arrSearchData['category_id'] > 0) {
@@ -349,7 +349,7 @@ class LC_Page_Products_List extends LC_Page_Ex
     public function lfGetProductAllNum($searchCondition)
     {
         // 検索結果対象となる商品の数を取得
-        $objQuery   =& SC_Query_Ex::getSingletonInstance();
+        $objQuery   = SC_Query_Ex::getSingletonInstance();
         $objQuery->setWhere($searchCondition['where_for_count']);
         $objProduct = new SC_Product_Ex();
 

--- a/data/class/pages/products/LC_Page_Products_Review.php
+++ b/data/class/pages/products/LC_Page_Products_Review.php
@@ -170,7 +170,7 @@ class LC_Page_Products_Review extends LC_Page_Ex
      */
     public function lfGetProductName($product_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         return $objQuery->get('name', 'dtb_products', 'product_id = ? AND ' . SC_Product_Ex::getProductDispConditions(), array($product_id));
     }
@@ -178,7 +178,7 @@ class LC_Page_Products_Review extends LC_Page_Ex
     //登録実行
     public function lfRegistRecommendData(&$objFormParam)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objCustomer = new SC_Customer_Ex();
 
         $arrRegist = $objFormParam->getDbArray();

--- a/data/class/pages/upgrade/LC_Page_Upgrade_Base.php
+++ b/data/class/pages/upgrade/LC_Page_Upgrade_Base.php
@@ -32,7 +32,7 @@ class LC_Page_Upgrade_Base extends LC_Page_Ex
     public function autoUpdateEnable($product_id)
     {
         $where = 'module_id = ?';
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrRet = $objQuery->select('auto_update_flg', 'dtb_module', $where, array($product_id));
 
         if (isset($arrRet[0]['auto_update_flg'])
@@ -95,7 +95,7 @@ class LC_Page_Upgrade_Base extends LC_Page_Ex
 
     public function getPublicKey()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrRet = $objQuery->select('*', 'dtb_ownersstore_settings');
 
         return isset($arrRet[0]['public_key'])

--- a/data/class/pages/upgrade/LC_Page_Upgrade_Download.php
+++ b/data/class/pages/upgrade/LC_Page_Upgrade_Download.php
@@ -267,7 +267,7 @@ class LC_Page_Upgrade_Download extends LC_Page_Upgrade_Base
     {
         $table = 'dtb_module';
         $where = 'module_id = ?';
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $exists = $objQuery->exists($table, $where, array($objRet->product_id));
         if ($exists) {
@@ -370,7 +370,7 @@ class LC_Page_Upgrade_Download extends LC_Page_Upgrade_Base
 
     public function registerUpdateLog($arrLog, $objRet)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrInsert = array(
             'log_id'      => $objQuery->nextVal('dtb_module_update_logs_log_id'),
             'module_id'   => $objRet->product_id,

--- a/data/class/plugin/SC_Plugin_Installer.php
+++ b/data/class/plugin/SC_Plugin_Installer.php
@@ -74,7 +74,7 @@ class SC_Plugin_Installer
             return $arrErr;
         }
 
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // SQLの実行
         if (!SC_Utils_Ex::isBlank($arrSql)) {
@@ -236,7 +236,7 @@ class SC_Plugin_Installer
     protected function verifySql($sql, $params)
     {
         // FIXME $paramsのチェックも行いたい.
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // force runを有効にし, システムエラーを回避する
         $objQuery->force_run = true;

--- a/data/class/plugin/SC_Plugin_Util.php
+++ b/data/class/plugin/SC_Plugin_Util.php
@@ -29,7 +29,7 @@ class SC_Plugin_Util
      */
     public function getEnablePlugin()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = '*';
         $table = 'dtb_plugin';
         $where = 'enable = 1';
@@ -58,7 +58,7 @@ class SC_Plugin_Util
      */
     public function getAllPlugin()
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = '*';
         $table = 'dtb_plugin';
         // XXX 2.11.0 互換のため
@@ -79,7 +79,7 @@ class SC_Plugin_Util
      */
     public function getPluginByPluginId($plugin_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = '*';
         $table = 'dtb_plugin';
         $where = 'plugin_id = ?';
@@ -96,7 +96,7 @@ class SC_Plugin_Util
      */
     public function getPluginByPluginCode($plugin_code)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $col = '*';
         $table = 'dtb_plugin';
         $where = 'plugin_code = ?';
@@ -113,7 +113,7 @@ class SC_Plugin_Util
      */
     public function deletePluginByPluginId($plugin_id)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $where = 'plugin_id = ?';
         $objQuery->delete('dtb_plugin', $where, array($plugin_id));
         $objQuery->delete('dtb_plugin_hookpoint', $where, array($plugin_id));
@@ -148,7 +148,7 @@ class SC_Plugin_Util
      */
     public function getPluginHookPoint($plugin_id, $use_type = 1)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $cols = '*';
         $from = 'dtb_plugin_hookpoint';
         $where = 'plugin_id = ?';
@@ -177,7 +177,7 @@ class SC_Plugin_Util
      */
     public function getPluginHookPointList($use_type = 3)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->setOrder('hook_point ASC, priority DESC');
         $cols = 'dtb_plugin_hookpoint.*, dtb_plugin.priority, dtb_plugin.plugin_name';
         $from = 'dtb_plugin_hookpoint LEFT JOIN dtb_plugin USING(plugin_id)';
@@ -240,7 +240,7 @@ class SC_Plugin_Util
      */
     public function setPluginHookPointChangeUse($plugin_hookpoint_id, $use_flg = 0)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $sqlval['use_flg'] = $use_flg;
         $objQuery->update('dtb_plugin_hookpoint', $sqlval, 'plugin_hookpoint_id = ?', array($plugin_hookpoint_id));
     }
@@ -265,7 +265,7 @@ class SC_Plugin_Util
         $conflict_alert_message = '';
         $arrConflictPluginName = array();
         $arrConflictHookPoint = array();
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->setGroupBy('T1.hook_point, T1.plugin_id, T2.plugin_name');
         $table = 'dtb_plugin_hookpoint AS T1 LEFT JOIN dtb_plugin AS T2 ON T1.plugin_id = T2.plugin_id';
         foreach ($hookPoints as $hookPoint) {

--- a/data/class/sessionfactory/SC_SessionFactory_UseRequest.php
+++ b/data/class/sessionfactory/SC_SessionFactory_UseRequest.php
@@ -81,7 +81,7 @@ class SC_SessionFactory_UseRequest extends SC_SessionFactory_Ex
         $url = $matches[1];
         $lifetime = $this->state->getLifeTime();
         $time = date('Y-m-d H:i:s', time() - $lifetime);
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         foreach ($_REQUEST as $key => $value) {
             $session_id = $objQuery->get('session_id', 'dtb_mobile_ext_session_id',
@@ -105,7 +105,7 @@ class SC_SessionFactory_UseRequest extends SC_SessionFactory_Ex
      */
     public function setExtSessionId($param_key, $param_value, $url)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         // GC
         $lifetime = $this->state->getLifeTime();

--- a/data/class/util/SC_Utils.php
+++ b/data/class/util/SC_Utils.php
@@ -775,7 +775,7 @@ class SC_Utils
         $sql.= 'from dtb_class inner join dtb_classcategory on dtb_class.class_id = dtb_classcategory.class_id ';
         $sql.= 'where dtb_class.del_flg = 0 AND dtb_classcategory.del_flg = 0 ';
         $sql.= 'group by dtb_class.class_id, dtb_class.name';
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrList = $objQuery->getAll($sql);
         // キーと値をセットした配列を取得
         $arrRet = SC_Utils_Ex::sfArrKeyValue($arrList, 'class_id', 'count');
@@ -799,7 +799,7 @@ class SC_Utils
         if (!$classcategory_id2) {
           $classcategory_id2 = 0;
         }
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
         $ret = $objQuery->get('product_class_id', 'dtb_products_class', $where, Array($product_id, $classcategory_id1, $classcategory_id2));
 
         return $ret;
@@ -1560,7 +1560,7 @@ class SC_Utils
      */
     public static function sfGetAddress($zipcode)
     {
-        $objQuery =& SC_Query_Ex::getSingletonInstance();
+        $objQuery = SC_Query_Ex::getSingletonInstance();
 
         $masterData = new SC_DB_MasterData_Ex();
         $arrPref = $masterData->getMasterData('mtb_pref');


### PR DESCRIPTION
 $objQuery =& SC_Query_Ex::getSingletonInstance();
↓
 $objQuery = SC_Query_Ex::getSingletonInstance();
に統一。

元々はPHP4互換のために参照代入にしていたと思うが、2.12以降でPHP4非対応になって久しい。
現状は、参照代入している箇所としていない箇所が混在しており、もはや不要かと思われるので参照代入をしないように統一。
