### PR TITLE
fix #156 nan円への対応

### DIFF
--- a/data/class/pages/admin/total/LC_Page_Admin_Total.php
+++ b/data/class/pages/admin/total/LC_Page_Admin_Total.php
@@ -814,6 +814,9 @@ __EOS__;
             }
             // 平均値の計算
             $arrTotal['total_average'] = $arrTotal['total'] / $arrTotal['total_order'];
+            if (is_nan($arrTotal['total_average'])) {
+                $arrTotal['total_average'] = 0;
+            }
             $arrResults[] = $arrTotal;
         }
 


### PR DESCRIPTION
・2005年1月度（末日締め）で月度集計を行う
・一番下の購入平均の金額が「nan円」になっている。