### PR TITLE
fix #156 売上集計CSVダウンロードの不具合

### DIFF
--- a/data/class/pages/LC_Page.php
+++ b/data/class/pages/LC_Page.php
@@ -166,7 +166,6 @@ class LC_Page
      */
     public function sendResponseCSV($file_name, $data)
     {
-        $this->objDisplay->prepare($this);
         $this->objDisplay->addHeader('Content-disposition', "attachment; filename=${file_name}");
         $this->objDisplay->addHeader('Content-type', "application/octet-stream; name=${file_name}");
         $this->objDisplay->addHeader('Cache-Control', '');
@@ -444,7 +443,7 @@ class LC_Page
                 if (!SC_Helper_Session_Ex::isValidToken(false)) {
                     SC_Utils_Ex::sfDispError(INVALID_MOVE_ERRORR);
                     SC_Response_Ex::actionExit();
-                }   
+                }
             }
         } else {
             if ($_SERVER['REQUEST_METHOD'] == 'POST') {


### PR DESCRIPTION
・CSVダウンロードボタンを押すとシステムエラー
Fatal error(E_ERROR): Uncaught --> Smarty: Unable to load template 'file:main_frame.tpl' <--
thrown on [C:\xampp\htdocs\ec-cube-extended-improve-php7\ec-cube-extended-improve-php7\data\module\smarty-3.1.30\smarty-3.1.30\libs\sysplugins\smarty_internal_template.php(163)] from 192.168.1.16
login_id = admin(0)[9sk9p7d94k941c9arr0m2nngt9]
