### PR TITLE
fix #156 Warning: Declaration of の修正

### DIFF
--- a/data/class/SC_CustomerList.php
+++ b/data/class/SC_CustomerList.php
@@ -371,8 +371,8 @@ class SC_CustomerList extends SC_SelectSql_Ex
         return $this->getSql(2);
     }
 
-    public function getWhere()
+    public function getWhere($with_where = false)
     {
-        return array(parent::getWhere(), $this->arrVal);
+        return array(parent::getWhere($with_where), $this->arrVal);
     }
 }


### PR DESCRIPTION
会員検索ボタンを押すと以下エラー
2017/08/31 13:44:17 [/admin/customer/index.php] Warning(E_WARNING): Declaration of SC_CustomerList::getWhere() should be compatible with SC_SelectSql::getWhere($with_where = false) on [C:\xampp\htdocs\ec-cube-extended-improve-
php7\ec-cube-extended-improve-php7\data\class\SC_CustomerList.php(27)] from 192.168.1.16