### PR TITLE
Use mailcatcher appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@
 # Set build version format here instead of in the admin panel.
 version: 2.17-dev-{build}
 
+image: Visual Studio 2017
+
 clone_folder: C:\projects\eccube2
 
 cache:
@@ -33,6 +35,8 @@ services:
 
 # Install scripts. (runs after repo cloning)
 install:
+  - docker pull nanasess/mailcatcher:windowsservercore
+  - docker run -d -p 1080:1080 -p 1025:1025 --name mailcatcher nanasess/mailcatcher:windowsservercore
   - cinst -y OpenSSL.Light --version 1.1.1
   - SET PATH=C:\Program Files\OpenSSL;%PATH%
   - sc config wuauserv start= auto

--- a/tests/class/SC_SendMailTest.php
+++ b/tests/class/SC_SendMailTest.php
@@ -1,0 +1,171 @@
+<?php
+
+class SC_SendMailTest extends Common_TestCase
+{
+    /**
+     * @var SC_SendMail
+     */
+    protected $objSendMail;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->objSendMail = new SC_SendMail_Ex();
+    }
+
+    public function testGetInstance()
+    {
+        $this->assertInstanceOf('SC_SendMail', $this->objSendMail);
+    }
+
+    public function testSendMail()
+    {
+        $this->resetEmails();
+
+        $this->objSendMail->setItem('to@example.com', '件名', '本文', 'from@example.com', '差出人名', 'reply-to@example.com', 'return-path@example.com', 'error-to@example.com', 'bcc@example.com', 'cc@example.com');
+        $result = $this->objSendMail->sendMail();
+        $this->assertTrue($result);
+
+        $messages = $this->getMailCatcherMessages();
+        $this->assertCount(1, $messages);
+
+        $message = $this->getLastMailCatcherMessage();
+        $this->assertEquals('件名', $message['subject']);
+        $this->assertContains('本文', $message['source']);
+
+        $this->assertContains('text/plain', $message['source']);
+
+        $this->assertContains('Return-Path: error-to@example.com', $message['source']);
+    }
+
+    public function testSendHtmlMail()
+    {
+        $this->resetEmails();
+
+        $this->objSendMail->setItemHtml('to@example.com', '件名', '<p>本文</p>', 'from@example.com', '差出人名', 'reply-to@example.com', 'return-path@example.com', 'error-to@example.com', 'bcc@example.com', 'cc@example.com');
+        $result = $this->objSendMail->sendHtmlMail();
+        $this->assertTrue($result);
+
+        $messages = $this->getMailCatcherMessages();
+        $this->assertCount(1, $messages);
+
+        $message = $this->getLastMailCatcherMessage();
+        $this->assertEquals('件名', $message['subject']);
+        $this->assertContains('<p>本文</p>', $message['source']);
+
+        $this->assertContains('text/html', $message['source']);
+    }
+
+    public function testSetReturnPathToSendMail()
+    {
+        $this->resetEmails();
+
+        $this->objSendMail->setBase('to@example.com', '件名', '本文', 'from@example.com', '差出人名', 'reply-to@example.com');
+
+        $this->objSendMail->setReturnPath('return-path@example.com');
+        $result = $this->objSendMail->sendMail();
+        $this->assertTrue($result);
+
+        $messages = $this->getMailCatcherMessages();
+        $this->assertCount(1, $messages);
+
+        $message = $this->getLastMailCatcherMessage();
+        $this->assertEquals('件名', $message['subject']);
+        $this->assertContains('本文', $message['source']);
+        $this->assertContains('text/plain', $message['source']);
+
+        $this->assertContains('Return-Path: return-path@example.com', $message['source']);
+    }
+
+    public function testUnsetErrorToSendMail()
+    {
+        $this->resetEmails();
+
+        $this->objSendMail->setItem('to@example.com', '件名', '本文', 'from@example.com', '差出人名', 'reply-to@example.com', 'return-path@example.com');
+        $result = $this->objSendMail->sendMail();
+        $this->assertTrue($result);
+
+        $messages = $this->getMailCatcherMessages();
+        $this->assertCount(1, $messages);
+
+        $message = $this->getLastMailCatcherMessage();
+        $this->assertEquals('件名', $message['subject']);
+        $this->assertContains('本文', $message['source']);
+
+        $this->assertContains('text/plain', $message['source']);
+
+        $this->assertContains('Return-Path: return-path@example.com', $message['source']);
+    }
+
+    public function testUnsetReturnPathToSendMail()
+    {
+        $this->resetEmails();
+
+        $this->objSendMail->setItem('to@example.com', '件名', '本文', 'from@example.com', '差出人名', 'reply-to@example.com');
+        $result = $this->objSendMail->sendMail();
+        $this->assertTrue($result);
+
+        $messages = $this->getMailCatcherMessages();
+        $this->assertCount(1, $messages);
+
+        $message = $this->getLastMailCatcherMessage();
+        $this->assertEquals('件名', $message['subject']);
+        $this->assertContains('本文', $message['source']);
+
+        $this->assertContains('text/plain', $message['source']);
+
+        $this->assertContains('Return-Path: from@example.com', $message['source']);
+    }
+
+    public function testGetRecip()
+    {
+        $this->objSendMail->setItem('to@example.com', '件名', '本文', 'from@example.com', '差出人名', 'reply-to@example.com');
+
+        $this->objSendMail->backend = 'mail';
+        $this->expected = 'to@example.com';
+        $this->actual = $this->objSendMail->getRecip();
+        $this->verify();
+
+        $this->objSendMail->backend = 'smtp';
+        $this->expected = [
+            'To' => 'to@example.com'
+        ];
+        $this->actual = $this->objSendMail->getRecip();
+        $this->verify();
+
+        $this->objSendMail->backend = 'sendmail';
+        $this->expected = [
+            'To' => 'to@example.com'
+        ];
+        $this->actual = $this->objSendMail->getRecip();
+        $this->verify();
+    }
+
+    public function testGetBackendParams()
+    {
+        $this->expected = [];
+        $this->actual = $this->objSendMail->getBackendParams('mail');
+        $this->verify();
+
+        $this->expected = [
+            'sendmail_path' => '/usr/bin/sendmail',
+            'sendmail_args' => '-i',
+        ];
+        $this->actual = $this->objSendMail->getBackendParams('sendmail');
+        $this->verify();
+
+        $this->expected = [
+            'host' => '127.0.0.1',
+            'port' => '1025'
+        ];
+        $this->actual = $this->objSendMail->getBackendParams('smtp');
+        $this->verify();
+
+        $this->expected = [
+            'host' => '127.0.0.1',
+            'port' => '1025'
+        ];
+        $this->actual = $this->objSendMail->getBackendParams('smtp');
+        $this->verify();
+    }
+}

--- a/tests/class/SC_SendMailTest.php
+++ b/tests/class/SC_SendMailTest.php
@@ -10,6 +10,7 @@ class SC_SendMailTest extends Common_TestCase
     protected function setUp()
     {
         parent::setUp();
+        $this->checkMailCatcherStatus();
         $this->objSendMail = new SC_SendMail_Ex();
     }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ AppVeyor で MailCatcher を使用す
+ https://github.com/EC-CUBE/ec-cube/pull/4138

## 方針(Policy)
+ VS2017 のイメージで Docker コンテナが利用できるようになったので、 MailCatcher の Docker コンテナを追加

## テスト（Test)
+ メール関係のテストがスキップされずに通ることを確認

## 相談（Discussion）
+ Windows Server Core のイメージは6GBくらいあり、 pull に時間がかかる(5分程度)
+ 本来は Nano Server を使用したいが、以下の問題があり、現在は Windows Server Core のイメージを使用している
   - Ruby 2.3.x までは SQLIte3 の gem のビルドに失敗する
   - Ruby 2.4.x 以降は Nano Server で Ruby が動かない
