### PR TITLE
DEVICE_TYPE_MOBILE 向けの出力バッファリングを削除

### DIFF
--- a/data/class/SC_Customer.php
+++ b/data/class/SC_Customer.php
@@ -68,6 +68,7 @@ class SC_Customer
      * FIXME
      * @return boolean 該当する会員が存在する場合は true、それ以外の場合
      *                 は false を返す。
+     * @deprecated
      */
     public function checkMobilePhoneId()
     {

--- a/data/class/SC_MobileEmoji.php
+++ b/data/class/SC_MobileEmoji.php
@@ -29,6 +29,7 @@ define('MOBILE_EMOJI_SUBSTITUTE', '');
 
 /**
  * 携帯端末の絵文字を扱うクラス
+ * @deprecated
  */
 class SC_MobileEmoji
 {

--- a/data/class/SC_MobileImage.php
+++ b/data/class/SC_MobileImage.php
@@ -28,6 +28,7 @@ require_once MOBILE_IMAGE_INC_REALDIR . 'image_converter.inc';
 
 /**
  * 画像変換クラス
+ * @deprecated
  */
 class SC_MobileImage
 {

--- a/data/class/SC_MobileUserAgent.php
+++ b/data/class/SC_MobileUserAgent.php
@@ -41,7 +41,7 @@ class SC_MobileUserAgent
      */
     public function getCarrier()
     {
-        trigger_error(E_USER_DEPRECATED, 'Net_UserAgent_Mobile is deprecated');
+        trigger_error('Net_UserAgent_Mobile is deprecated', E_USER_DEPRECATED);
         return false;
     }
 
@@ -58,7 +58,7 @@ class SC_MobileUserAgent
      */
     public function getId()
     {
-        trigger_error(E_USER_DEPRECATED, 'Net_UserAgent_Mobile is deprecated');
+        trigger_error('Net_UserAgent_Mobile is deprecated', E_USER_DEPRECATED);
         return false;
     }
 
@@ -70,7 +70,7 @@ class SC_MobileUserAgent
      */
     public function getModel()
     {
-        trigger_error(E_USER_DEPRECATED, 'Net_UserAgent_Mobile is deprecated');
+        trigger_error('Net_UserAgent_Mobile is deprecated', E_USER_DEPRECATED);
         return false;
     }
 
@@ -88,7 +88,7 @@ class SC_MobileUserAgent
      */
     public function isSupported()
     {
-        trigger_error(E_USER_DEPRECATED, 'Net_UserAgent_Mobile is deprecated');
+        trigger_error('Net_UserAgent_Mobile is deprecated', E_USER_DEPRECATED);
         return false;
     }
 
@@ -101,7 +101,7 @@ class SC_MobileUserAgent
      */
     public function isMobile()
     {
-        trigger_error(E_USER_DEPRECATED, 'Net_UserAgent_Mobile is deprecated');
+        trigger_error('Net_UserAgent_Mobile is deprecated', E_USER_DEPRECATED);
         return false;
     }
 }

--- a/data/class/SC_MobileView.php
+++ b/data/class/SC_MobileView.php
@@ -21,6 +21,9 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+/**
+ * @deprecated
+ */
 class SC_MobileView extends SC_SiteView_Ex
 {
     public function __construct($setPrevURL = true)

--- a/data/class/helper/SC_Helper_HandleError.php
+++ b/data/class/helper/SC_Helper_HandleError.php
@@ -200,21 +200,6 @@ class SC_Helper_HandleError
 
         ob_clean();
 
-        // 絵文字変換・除去フィルターが有効か評価する。
-        $loaded_ob_emoji = false;
-        $arrObs = ob_get_status(true);
-        foreach ($arrObs as $arrOb) {
-            if ($arrOb['name'] === 'SC_MobileEmoji::handler') {
-                $loaded_ob_emoji = true;
-                break;
-            }
-        }
-
-        // 絵文字変換・除去フィルターが無効で、利用できる場合、有効にする。
-        if (!$loaded_ob_emoji && class_exists('SC_MobileEmoji')) {
-            ob_start(array('SC_MobileEmoji', 'handler'));
-        }
-
         require_once CLASS_EX_REALDIR . 'page_extends/error/LC_Page_Error_SystemError_Ex.php';
         $objPage = new LC_Page_Error_SystemError_Ex();
         $objPage->init();

--- a/data/class/helper/SC_Helper_Mobile.php
+++ b/data/class/helper/SC_Helper_Mobile.php
@@ -27,6 +27,7 @@
  * @package Helper
  * @author EC-CUBE CO.,LTD.
  * @version $Id$
+ * @deprecated
  */
 class SC_Helper_Mobile
 {

--- a/data/class/sessionfactory/SC_SessionFactory_UseRequest.php
+++ b/data/class/sessionfactory/SC_SessionFactory_UseRequest.php
@@ -31,6 +31,7 @@
  * @package SC_SessionFactory
  * @author EC-CUBE CO.,LTD.
  * @version $Id$
+ * @deprecated
  */
 class SC_SessionFactory_UseRequest extends SC_SessionFactory_Ex
 {

--- a/data/include/image_converter.inc
+++ b/data/include/image_converter.inc
@@ -1,6 +1,7 @@
 <?php
 /**
  * 画像ファイルの変換を行う
+ * @deprecated
  */
 class ImageConverter
 {

--- a/html/require.php
+++ b/html/require.php
@@ -33,14 +33,3 @@ if (!defined('ADMIN_FUNCTION') || ADMIN_FUNCTION !== true) {
 
 require_once HTML_REALDIR . 'define.php';
 require_once HTML_REALDIR . HTML2DATA_DIR . 'require_base.php';
-
-// 絵文字変換 (除去) フィルターを組み込む。
-ob_start(array('SC_MobileEmoji', 'handler'));
-
-if (SC_Display_Ex::detectDevice() == DEVICE_TYPE_MOBILE) {
-    // resize_image.phpは除外
-    if (stripos($_SERVER['REQUEST_URI'], ROOT_URLPATH . 'resize_image.php') === FALSE) {
-        $objMobile = new SC_Helper_Mobile_Ex();
-        $objMobile->sfMobileInit();
-    }
-}


### PR DESCRIPTION
- DEVICE_TYPE_MOBILE 向けの出力バッファリングは使用しなくなったため削除
- SC_Mobilexxx, SC_Helper_Mobile 関連の処理に @deprecated 追加
- SC_MobileUserAgent の trigger_error の引数が逆だったのを修正