### PR TITLE
SC_Query::setWhere() で設定した検索条件が無視されていたのを修正

### DIFF
--- a/data/class/SC_Product.php
+++ b/data/class/SC_Product.php
@@ -87,7 +87,7 @@ class SC_Product
 
             $objQuery->setOrder("($sub_sql) $o_order, product_id");
         }
-        $arrReturn = $objQuery->getCol('alldtl.product_id', $table, 'alldtl.del_flg = 0', $arrVal);
+        $arrReturn = $objQuery->getCol('alldtl.product_id', $table, $objQuery->where ? '' : 'alldtl.del_flg = 0', $arrVal);
 
         return $arrReturn;
     }


### PR DESCRIPTION
#261 のデグレ修正

SC_Query::setWhere() で検索条件が設定されていても、無視されていたのを修正。
商品一覧がカテゴリで絞り込みでされない状態になっていた(カテゴリで絞り込んでも全商品が表示されていた)
