### PR TITLE
セキュリティ関連のヘッダ出力を PHP から送信するよう修正

### DIFF
--- a/data/class/pages/LC_Page.php
+++ b/data/class/pages/LC_Page.php
@@ -89,6 +89,7 @@ class LC_Page
      */
     public function init()
     {
+        $this->sendAdditionalHeader();
         // 開始時刻を設定する。
         $this->timeStart = microtime(true);
 
@@ -509,5 +510,17 @@ class LC_Page
             $msg = "REQUEST_METHOD=[{$_SERVER['REQUEST_METHOD']}]では実行不能な mode=[$mode] が指定されました。";
             trigger_error($msg, E_USER_ERROR);
         }
+    }
+
+    /**
+     * 追加の HTTP ヘッダを送信する.
+     *
+     * 主にセキュリティ関連のヘッダを送信する.
+     */
+    public function sendAdditionalHeader()
+    {
+        header('X-XSS-Protection: 1; mode=block');
+        header('X-Content-Type-Options: nosniff');
+        header('X-Frame-Options: DENY');
     }
 }

--- a/data/class/pages/admin/LC_Page_Admin.php
+++ b/data/class/pages/admin/LC_Page_Admin.php
@@ -43,6 +43,7 @@ class LC_Page_Admin extends LC_Page_Ex
      */
     public function init()
     {
+        $this->sendAdditionalHeader();
         $this->template = MAIN_FRAME;
 
         //IP制限チェック

--- a/data/class/pages/admin/system/LC_Page_Admin_System_System.php
+++ b/data/class/pages/admin/system/LC_Page_Admin_System_System.php
@@ -128,4 +128,14 @@ class LC_Page_Admin_System_System extends LC_Page_Admin_Ex
 
         return $arrSystemInfo;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sendAdditionalHeader()
+    {
+        header('X-XSS-Protection: 1; mode=block');
+        header('X-Content-Type-Options: nosniff');
+        header('X-Frame-Options: SAMEORIGIN');
+    }
 }

--- a/html/.htaccess
+++ b/html/.htaccess
@@ -1,9 +1,3 @@
-<ifModule mod_headers.c>
-Header always set X-XSS-Protection "1; mode=block"
-Header always set X-Content-Type-Options "nosniff"
-Header always set X-Frame-Options DENY
-</ifModule>
-
 # 基本は SC_Initial.php で設定するが、ini_setで反映されないものはここで設定する
 <IfModule mod_php5.c>
 php_value mbstring.language Japanese


### PR DESCRIPTION
- X-Frame-Options DENY の影響で phpinfo が表示されなかったのを修正
- see also
  - https://github.com/EC-CUBE/eccube-2_13/issues/48
  - https://github.com/EC-CUBE/eccube-2_13/issues/49
  - https://github.com/EC-CUBE/eccube-2_13/pull/206