### PR TITLE
LC_Page::plugin_activate_flg を非推奨に

### DIFF
--- a/data/class/SC_FormParam.php
+++ b/data/class/SC_FormParam.php
@@ -70,8 +70,7 @@ class SC_FormParam
         $backtraces = debug_backtrace();
         // 呼び出し元のクラスを取得
         $class = $backtraces[1]['class'];
-        $objPage = $backtraces[1]['object'];
-        $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance($objPage->plugin_activate_flg);
+        $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance();
         if (is_object($objPlugin)) {
             $objPlugin->doAction('SC_FormParam_construct', array($class, $this));
         }

--- a/data/class/SC_View.php
+++ b/data/class/SC_View.php
@@ -145,7 +145,7 @@ class SC_View
     {
         if (!is_null($this->objPage)) {
             // フックポイントを実行.
-            $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance($this->objPage->plugin_activate_flg);
+            $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance();
             if ($objPlugin) {
                 $objPlugin->doAction('prefilterTransform', array(&$source, $this->objPage, $template->smarty->_current_file));
             }
@@ -164,7 +164,7 @@ class SC_View
     {
         if (!is_null($this->objPage)) {
             // フックポイントを実行.
-            $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance($this->objPage->plugin_activate_flg);
+            $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance();
             if ($objPlugin) {
                 $objPlugin->doAction('outputfilterTransform', array(&$source, $this->objPage, $template->smarty->_current_file));
             }

--- a/data/class/helper/SC_Helper_Plugin.php
+++ b/data/class/helper/SC_Helper_Plugin.php
@@ -42,6 +42,7 @@ class SC_Helper_Plugin
      * 有効なプラグインのロード. プラグインエンジンが有効になっていない場合は
      * プラグインエンジン自身のインストール処理を起動する
      *
+     * @param bool $plugin_activate_flg プラグインを有効化する場合 true
      * @return void
      */
     public function load($plugin_activate_flg = true)
@@ -86,9 +87,10 @@ class SC_Helper_Plugin
     /**
      * SC_Helper_Plugin オブジェクトを返す（Singletonパターン）
      *
-     * @return object SC_Helper_Pluginオブジェクト
+     * @param bool $plugin_activate_flg プラグインを有効化する場合 true
+     * @return SC_Helper_Plugin SC_Helper_Pluginオブジェクト
      */
-    public static function getSingletonInstance($plugin_activate_flg = true)
+    public static function getSingletonInstance($plugin_activate_flg = PLUGIN_ACTIVATE_FLAG)
     {
         if (!isset($GLOBALS['_SC_Helper_Plugin_instance'])) {
             // プラグインのローダーがDB接続を必要とするため、

--- a/data/class/pages/LC_Page.php
+++ b/data/class/pages/LC_Page.php
@@ -67,7 +67,10 @@ class LC_Page
     /** 店舗基本情報 */
     public $arrSiteInfo;
 
-    /** プラグインを実行フラグ */
+    /**
+     * プラグインを実行フラグ
+     * @deprecated 定数 PLUGIN_ACTIVATE_FLAG を使用してください
+     */
     public $plugin_activate_flg = PLUGIN_ACTIVATE_FLAG;
 
     /** POST に限定する mode */
@@ -105,7 +108,7 @@ class LC_Page
         }
 
         // スーパーフックポイントを実行.
-        $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance($this->plugin_activate_flg);
+        $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance();
         $objPlugin->doAction('LC_Page_preProcess', array($this));
 
         // 店舗基本情報取得
@@ -137,7 +140,7 @@ class LC_Page
      */
     public function sendResponse()
     {
-        $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance($this->plugin_activate_flg);
+        $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance();
         // ローカルフックポイントを実行.
         $this->doLocalHookpointAfter($objPlugin);
 

--- a/data/class/pages/admin/LC_Page_Admin.php
+++ b/data/class/pages/admin/LC_Page_Admin.php
@@ -67,7 +67,7 @@ class LC_Page_Admin extends LC_Page_Ex
         $this->objDisplay = new SC_Display_Ex();
 
         // スーパーフックポイントを実行.
-        $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance($this->plugin_activate_flg);
+        $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance();
         $objPlugin->doAction('LC_Page_preProcess', array($this));
 
         // トランザクショントークンの検証と生成
@@ -99,7 +99,7 @@ class LC_Page_Admin extends LC_Page_Ex
      */
     public function sendResponse()
     {
-        $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance($this->plugin_activate_flg);
+        $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance();
         // ローカルフックポイントを実行
         $parent_class_name = get_parent_class($this);
         $objPlugin->doAction($parent_class_name . '_action_after', array($this));

--- a/data/class/pages/error/LC_Page_Error.php
+++ b/data/class/pages/error/LC_Page_Error.php
@@ -63,7 +63,7 @@ class LC_Page_Error extends LC_Page_Ex
         // ディスプレイクラス生成
         $this->objDisplay = new SC_Display_Ex();
 
-        $objHelperPlugin = SC_Helper_Plugin_Ex::getSingletonInstance($this->plugin_activate_flg);
+        $objHelperPlugin = SC_Helper_Plugin_Ex::getSingletonInstance();
         if (is_object($objHelperPlugin)) {
             // transformでフックしている場合に, 再度エラーが発生するため, コールバックを無効化.
             $objHelperPlugin->arrRegistedPluginActions = array();

--- a/data/class/pages/error/LC_Page_Error_DispError.php
+++ b/data/class/pages/error/LC_Page_Error_DispError.php
@@ -50,7 +50,7 @@ class LC_Page_Error_DispError extends LC_Page_Admin_Ex
         $this->objDisplay = new SC_Display_Ex();
 
         // transformでフックしている場合に, 再度エラーが発生するため, コールバックを無効化.
-        $objHelperPlugin = SC_Helper_Plugin_Ex::getSingletonInstance($this->plugin_activate_flg);
+        $objHelperPlugin = SC_Helper_Plugin_Ex::getSingletonInstance();
         $objHelperPlugin->arrRegistedPluginActions = array();
 
         // キャッシュから店舗情報取得（DBへの接続は行わない）

--- a/data/class/pages/frontparts/bloc/LC_Page_FrontParts_Bloc.php
+++ b/data/class/pages/frontparts/bloc/LC_Page_FrontParts_Bloc.php
@@ -53,7 +53,7 @@ class LC_Page_FrontParts_Bloc extends LC_Page_Ex
         $this->setTokenTo();
 
         // ローカルフックポイントを実行.
-        $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance($this->plugin_activate_flg);
+        $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance();
         $this->doLocalHookpointBefore($objPlugin);
     }
 

--- a/data/class/pages/mypage/LC_Page_Mypage_DownLoad.php
+++ b/data/class/pages/mypage/LC_Page_Mypage_DownLoad.php
@@ -104,7 +104,7 @@ class LC_Page_Mypage_DownLoad extends LC_Page_Ex
     public function sendResponse()
     {
         // TODO sendResponseをオーバーライドしている為、afterフックポイントが実行されない.直接実行する.(#1790)
-        $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance($this->plugin_activate_flg);
+        $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance();
         $objPlugin->doAction('LC_Page_Mypage_DownLoad_action_after', array($this));
 
         $this->objDisplay->noAction();

--- a/data/class/pages/products/LC_Page_Products_Detail.php
+++ b/data/class/pages/products/LC_Page_Products_Detail.php
@@ -652,7 +652,7 @@ class LC_Page_Products_Detail extends LC_Page_Ex
                 if (!$this->lfRegistFavoriteProduct($this->objFormParam->getValue('favorite_product_id'), $objCustomer->getValue('customer_id'))) {
                     SC_Response_Ex::actionExit(); 
                 }
-                $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance($this->plugin_activate_flg);
+                $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance();
                 $objPlugin->doAction('LC_Page_Products_Detail_action_add_favorite', array($this));
             }
         }
@@ -671,7 +671,7 @@ class LC_Page_Products_Detail extends LC_Page_Ex
             $this->arrErr = $this->lfCheckError($this->mode, $this->objFormParam);
             if (count($this->arrErr) == 0) {
                 if ($this->lfRegistFavoriteProduct($this->objFormParam->getValue('favorite_product_id'), $objCustomer->getValue('customer_id'))) {
-                    $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance($this->plugin_activate_flg);
+                    $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance();
                     $objPlugin->doAction('LC_Page_Products_Detail_action_add_favorite_sphone', array($this));
                     print 'true';
                     SC_Response_Ex::actionExit();


### PR DESCRIPTION
- https://github.com/EC-CUBE/eccube-2_13/commit/75f32263f3751ee8e80768ef51f1f86f46a63e9a のコミットで常に true となっているため、LC_Page のメンバ変数は非推奨にして問題ない
- SC_Helper_Plugin::getSingletonInstance() の引数のデフォルト値を PLUGIN_ACTIVATE_FLAG とするよう修正
- 基本的に常に PLUGIN_ACTIVATE_FLAG の値を参照するよう修正
- https://github.com/EC-CUBE/eccube-2_13/issues/142