### PR TITLE
売上集計の期間設定の初期値が選択されていなかったのを修正

### DIFF
--- a/ctests/_support/AcceptanceTester.php
+++ b/ctests/_support/AcceptanceTester.php
@@ -23,4 +23,37 @@ class AcceptanceTester extends \Codeception\Actor
    /**
     * Define custom actions here
     */
+
+    /**
+     * @param string|$fileNameRegex ファイル名のパターン(CI環境で同時実行したときに区別するため)
+     * @param int $retryCount リトライカウント数
+     * @param string $downloadDir ダウンロードディレクトリ
+     *
+     * @return string|bool ファイルパス. ファイルが見つからない場合 false
+     */
+    public function getLastDownloadFile($fileNameRegex, $retryCount = 3, $downloadDir = '/tmp')
+    {
+        $files = scandir($downloadDir);
+        $files = array_map(function ($fileName) use ($downloadDir) {
+            return $downloadDir.'/'.$fileName;
+        }, $files);
+        $files = array_filter($files, function ($f) use ($fileNameRegex) {
+            return is_file($f) && preg_match($fileNameRegex, basename($f));
+        });
+
+        usort($files, function ($l, $r) {
+            return filemtime($l) - filemtime($r);
+        });
+
+        if (empty($files)) {
+            if ($retryCount > 0) {
+                $this->wait(3);
+
+                return $this->getLastDownloadFile($fileNameRegex, $retryCount - 1, $downloadDir);
+            }
+            return false;
+        }
+
+        return end($files);
+    }
 }

--- a/ctests/acceptance.suite.yml
+++ b/ctests/acceptance.suite.yml
@@ -9,6 +9,7 @@ modules:
     enabled:
         - AcceptanceHelper
         - WebDriver
+        - Asserts
         - MailCatcherGuzzle5
     config:
         PhpBrowser:
@@ -41,4 +42,4 @@ env:
                     capabilities:
                         chromeOptions:
                             prefs:
-                                download.default_directory: '%PWD%/codeception/_support/_downloads'
+                                download.default_directory: '/tmp'

--- a/ctests/acceptance/AdminTotalCept.php
+++ b/ctests/acceptance/AdminTotalCept.php
@@ -1,5 +1,8 @@
 <?php
 $I = new AcceptanceTester($scenario);
+if (!function_exists('ImageTTFText')) {
+    $scenario->skip('Freetype not supported.');
+}
 $I->wantTo('売上集計画面を確認する');
 $I->amOnPage('/admin');
 

--- a/ctests/acceptance/AdminTotalCept.php
+++ b/ctests/acceptance/AdminTotalCept.php
@@ -1,0 +1,254 @@
+<?php
+$I = new AcceptanceTester($scenario);
+$I->wantTo('売上集計画面を確認する');
+$I->amOnPage('/admin');
+
+$I->fillField('input[name=login_id]', 'admin');
+$I->fillField('input[name=password]', 'password');
+$I->click(['css' => '.btn-tool-format']);
+
+$I->see('ログイン : 管理者 様');
+
+$I->amGoingTo('売上集計＞期間別集計');
+$I->amOnPage('/admin/total/?page=term');
+
+$I->expect('日付の初期値を確認する');
+$I->seeInField('select[name=search_startyear_m]', date('Y'));
+$I->seeInField('select[name=search_startmonth_m]', date('n'));
+
+$I->seeInField('select[name=search_startyear]', date('Y'));
+$I->seeInField('select[name=search_startmonth]', date('n'));
+$I->seeInField('select[name=search_startday]', date('j'));
+
+$I->seeInField('select[name=search_endyear]', date('Y'));
+$I->seeInField('select[name=search_endmonth]', date('n'));
+$I->seeInField('select[name=search_endday]', date('j'));
+
+$I->amGoingTo('売上集計>期間別集計>月度集計');
+$I->click('月度で集計する');
+
+$I->expect('グラフの表示を確認する');
+$I->seeElement(['css' => '#graph-image > img']);
+$I->expect('表の表示を確認する');
+$I->seeElement(['id' => 'total-term']);
+
+$I->amGoingTo('売上集計>期間別集計>期間集計');
+$I->selectOption('select[name=search_startyear]', date('Y', strtotime('-1 year')));
+$I->click('期間で集計する');
+
+$I->expect('グラフの表示を確認する');
+$I->seeElement(['css' => '#graph-image > img']);
+$I->expect('表の表示を確認する');
+$I->seeElement(['id' => 'total-term']);
+
+$I->amGoingTo('売上集計>期間別集計>期間集計>月別');
+$I->click('月別');
+
+$I->expect('グラフの表示を確認する');
+$I->seeElement(['css' => '#graph-image > img']);
+$I->expect('表の表示を確認する');
+$I->seeElement(['id' => 'total-term']);
+
+$I->amGoingTo('売上集計>期間別集計>期間集計>年別');
+$I->click('年別');
+
+$I->expect('グラフの表示を確認する');
+$I->seeElement(['css' => '#graph-image > img']);
+$I->expect('表の表示を確認する');
+$I->seeElement(['id' => 'total-term']);
+
+$I->amGoingTo('売上集計>期間別集計>期間集計>曜日別');
+$I->click('曜日別');
+
+$I->expect('グラフの表示を確認する');
+$I->seeElement(['css' => '#graph-image > img']);
+$I->expect('表の表示を確認する');
+$I->seeElement(['id' => 'total-term']);
+
+$I->amGoingTo('売上集計>期間別集計>期間集計>時間別');
+$I->click('時間別');
+
+$I->expect('グラフの表示を確認する');
+$I->seeElement(['css' => '#graph-image > img']);
+$I->expect('表の表示を確認する');
+$I->seeElement(['id' => 'total-term']);
+
+$I->click('CSVダウンロード');
+$file = $I->getLastDownloadFile('/^total\d{12}\.csv$/');
+$I->assertTrue(count(file($file)) >= 2, '2行以上のファイルがダウンロードされている');
+
+$I->amGoingTo('売上集計＞商品別集計');
+$I->amOnPage('/admin/total/?page=products');
+
+$I->expect('日付の初期値を確認する');
+$I->seeInField('select[name=search_startyear_m]', date('Y'));
+$I->seeInField('select[name=search_startmonth_m]', date('n'));
+
+$I->seeInField('select[name=search_startyear]', date('Y'));
+$I->seeInField('select[name=search_startmonth]', date('n'));
+$I->seeInField('select[name=search_startday]', date('j'));
+
+$I->seeInField('select[name=search_endyear]', date('Y'));
+$I->seeInField('select[name=search_endmonth]', date('n'));
+$I->seeInField('select[name=search_endday]', date('j'));
+
+$I->amGoingTo('売上集計>商品別集計>月度集計');
+$I->click('月度で集計する');
+
+$I->expect('グラフの表示を確認する');
+$I->seeElement(['css' => '#graph-image > img']);
+$I->expect('表の表示を確認する');
+$I->seeElement(['id' => 'total-products']);
+
+$I->amGoingTo('売上集計>商品集計>期間集計');
+$I->selectOption('select[name=search_startyear]', date('Y', strtotime('-1 year')));
+$I->click('期間で集計する');
+
+$I->expect('グラフの表示を確認する');
+$I->seeElement(['css' => '#graph-image > img']);
+$I->expect('表の表示を確認する');
+$I->seeElement(['id' => 'total-products']);
+
+$I->amGoingTo('売上集計>商品集計>期間集計>会員');
+$I->click('会員');
+
+$I->expect('グラフの表示を確認する');
+$I->seeElement(['css' => '#graph-image > img']);
+$I->expect('表の表示を確認する');
+$I->seeElement(['id' => 'total-products']);
+
+$I->amGoingTo('売上集計>商品集計>期間集計>非会員');
+$I->click('非会員');
+
+$I->expect('グラフの表示を確認する');
+$I->seeElement(['css' => '#graph-image > img']);
+$I->expect('表の表示を確認する');
+$I->seeElement(['id' => 'total-products']);
+
+$I->click('CSVダウンロード');
+$file = $I->getLastDownloadFile('/^total\d{12}\.csv$/');
+$I->assertTrue(count(file($file)) >= 2, '2行以上のファイルがダウンロードされている');
+
+$I->amGoingTo('売上集計＞年代別集計');
+$I->amOnPage('/admin/total/?page=age');
+
+$I->expect('日付の初期値を確認する');
+$I->seeInField('select[name=search_startyear_m]', date('Y'));
+$I->seeInField('select[name=search_startmonth_m]', date('n'));
+
+$I->seeInField('select[name=search_startyear]', date('Y'));
+$I->seeInField('select[name=search_startmonth]', date('n'));
+$I->seeInField('select[name=search_startday]', date('j'));
+
+$I->seeInField('select[name=search_endyear]', date('Y'));
+$I->seeInField('select[name=search_endmonth]', date('n'));
+$I->seeInField('select[name=search_endday]', date('j'));
+
+$I->amGoingTo('売上集計>年代別集計>月度集計');
+$I->click('月度で集計する');
+
+$I->expect('グラフの表示を確認する');
+$I->seeElement(['css' => '#graph-image > img']);
+$I->expect('表の表示を確認する');
+$I->seeElement(['id' => 'total-age']);
+
+$I->amGoingTo('売上集計>年代別集計>期間集計');
+$I->selectOption('select[name=search_startyear]', date('Y', strtotime('-1 year')));
+$I->click('期間で集計する');
+
+$I->expect('グラフの表示を確認する');
+$I->seeElement(['css' => '#graph-image > img']);
+$I->expect('表の表示を確認する');
+$I->seeElement(['id' => 'total-age']);
+
+$I->amGoingTo('売上集計>年代別集計>期間集計>会員');
+$I->click('会員');
+
+$I->expect('グラフの表示を確認する');
+$I->seeElement(['css' => '#graph-image > img']);
+$I->expect('表の表示を確認する');
+$I->seeElement(['id' => 'total-age']);
+
+$I->amGoingTo('売上集計>年代別集計>期間集計>非会員');
+$I->click('非会員');
+
+$I->expect('グラフの表示を確認する');
+$I->seeElement(['css' => '#graph-image > img']);
+$I->expect('表の表示を確認する');
+$I->seeElement(['id' => 'total-age']);
+
+$I->click('CSVダウンロード');
+$file = $I->getLastDownloadFile('/^total\d{12}\.csv$/');
+$I->assertTrue(count(file($file)) >= 2, '2行以上のファイルがダウンロードされている');
+
+$I->amGoingTo('売上集計＞職業別集計');
+$I->amOnPage('/admin/total/?page=job');
+
+$I->expect('日付の初期値を確認する');
+$I->seeInField('select[name=search_startyear_m]', date('Y'));
+$I->seeInField('select[name=search_startmonth_m]', date('n'));
+
+$I->seeInField('select[name=search_startyear]', date('Y'));
+$I->seeInField('select[name=search_startmonth]', date('n'));
+$I->seeInField('select[name=search_startday]', date('j'));
+
+$I->seeInField('select[name=search_endyear]', date('Y'));
+$I->seeInField('select[name=search_endmonth]', date('n'));
+$I->seeInField('select[name=search_endday]', date('j'));
+
+$I->amGoingTo('売上集計>職業別集計>月度集計');
+$I->click('月度で集計する');
+
+$I->expect('グラフの表示を確認する');
+$I->seeElement(['css' => '#graph-image > img']);
+$I->expect('表の表示を確認する');
+$I->seeElement(['id' => 'total-job']);
+
+$I->amGoingTo('売上集計>職業別集計>期間集計');
+$I->selectOption('select[name=search_startyear]', date('Y', strtotime('-1 year')));
+$I->click('期間で集計する');
+
+$I->expect('グラフの表示を確認する');
+$I->seeElement(['css' => '#graph-image > img']);
+$I->expect('表の表示を確認する');
+$I->seeElement(['id' => 'total-job']);
+
+$I->click('CSVダウンロード');
+$file = $I->getLastDownloadFile('/^total\d{12}\.csv$/');
+$I->assertTrue(count(file($file)) >= 2, '2行以上のファイルがダウンロードされている');
+
+$I->amGoingTo('売上集計＞会員別集計');
+$I->amOnPage('/admin/total/?page=member');
+
+$I->expect('日付の初期値を確認する');
+$I->seeInField('select[name=search_startyear_m]', date('Y'));
+$I->seeInField('select[name=search_startmonth_m]', date('n'));
+
+$I->seeInField('select[name=search_startyear]', date('Y'));
+$I->seeInField('select[name=search_startmonth]', date('n'));
+$I->seeInField('select[name=search_startday]', date('j'));
+
+$I->seeInField('select[name=search_endyear]', date('Y'));
+$I->seeInField('select[name=search_endmonth]', date('n'));
+$I->seeInField('select[name=search_endday]', date('j'));
+
+$I->amGoingTo('売上集計>会員別集計>月度集計');
+$I->click('月度で集計する');
+
+$I->expect('グラフの表示を確認する');
+$I->seeElement(['css' => '#graph-image > img']);
+$I->expect('表の表示を確認する');
+$I->seeElement(['id' => 'total-member']);
+
+$I->amGoingTo('売上集計会員別集計>期間集計');
+$I->selectOption('select[name=search_startyear]', date('Y', strtotime('-1 year')));
+$I->click('期間で集計する');
+
+$I->expect('グラフの表示を確認する');
+$I->seeElement(['css' => '#graph-image > img']);
+$I->expect('表の表示を確認する');
+$I->seeElement(['id' => 'total-member']);
+
+$I->click('CSVダウンロード');
+$file = $I->getLastDownloadFile('/^total\d{12}\.csv$/');
+$I->assertTrue(count(file($file)) >= 2, '2行以上のファイルがダウンロードされている');

--- a/ctests/acceptance/_bootstrap.php
+++ b/ctests/acceptance/_bootstrap.php
@@ -48,6 +48,7 @@ if ($num < ($config['fixture_product_num'] + 2)) {
 
 $num = $objQuery->count('dtb_order');
 $customer_ids = $objQuery->getCol('customer_id', 'dtb_customer', 'del_flg = 0');
+array_unshift($customer_ids, '0'); // 非会員の注文を追加する
 $product_class_ids = $objQuery->getCol('product_class_id', 'dtb_products_class', 'del_flg = 0');
 if ($num < $config['fixture_order_num']) {
     echo 'Generating Orders';

--- a/ctests/acceptance/_bootstrap.php
+++ b/ctests/acceptance/_bootstrap.php
@@ -52,7 +52,7 @@ $product_class_ids = $objQuery->getCol('product_class_id', 'dtb_products_class',
 if ($num < $config['fixture_order_num']) {
     echo 'Generating Orders';
     foreach ($customer_ids as $customer_id) {
-        $target_product_class_ids = $product_class_ids[$faker->numberBetween(0, count($product_class_ids) - 1)];
+        $target_product_class_ids = array_rand($product_class_ids, $faker->numberBetween(0, count($product_class_ids) - 1));
         $charge = $faker->randomNumber(4);
         $discount = $faker->numberBetween(0, $charge);
         $order_count_per_customer = $objQuery->count('dtb_order', 'customer_id = ?', [$customer_id]);

--- a/ctests/acceptance/_bootstrap.php
+++ b/ctests/acceptance/_bootstrap.php
@@ -40,7 +40,7 @@ if ($num < ($config['fixture_product_num'] + 2)) {
 
     $category_ids = $objGenerator->createCategories();
     foreach ($product_ids as $product_id) {
-        $objGenerator->relateProductCategories($product_id, array_rand($category_ids, $faker->numberBetween(1, count($category_ids) - 1)));
+        $objGenerator->relateProductCategories($product_id, array_rand(array_flip($category_ids), $faker->numberBetween(2, count($category_ids) - 1)));
     }
     $objDb = new SC_Helper_DB_Ex();
     $objDb->sfCountCategory($objQuery);
@@ -52,7 +52,7 @@ $product_class_ids = $objQuery->getCol('product_class_id', 'dtb_products_class',
 if ($num < $config['fixture_order_num']) {
     echo 'Generating Orders';
     foreach ($customer_ids as $customer_id) {
-        $target_product_class_ids = array_rand($product_class_ids, $faker->numberBetween(0, count($product_class_ids) - 1));
+        $target_product_class_ids = array_rand(array_flip($product_class_ids), $faker->numberBetween(2, count($product_class_ids) - 1));
         $charge = $faker->randomNumber(4);
         $discount = $faker->numberBetween(0, $charge);
         $order_count_per_customer = $objQuery->count('dtb_order', 'customer_id = ?', [$customer_id]);

--- a/data/class/pages/admin/total/LC_Page_Admin_Total.php
+++ b/data/class/pages/admin/total/LC_Page_Admin_Total.php
@@ -164,10 +164,10 @@ class LC_Page_Admin_Total extends LC_Page_Admin_Ex
     public function lfGetDateDefault()
     {
         $year = date('Y');
-        $month = date('m');
-        $day = date('d');
+        $month = date('n');
+        $day = date('j');
 
-        $list = isset($_SESSION['total']) ? $_SESSION['total'] : '';
+        $list = isset($_SESSION['total']) ? $_SESSION['total'] : [];
 
         // セッション情報に開始月度が保存されていない。
         if (empty($_SESSION['total']['startyear_m'])) {
@@ -265,8 +265,8 @@ class LC_Page_Admin_Total extends LC_Page_Admin_Ex
     public function lfGetDateInit()
     {
         $search_startyear_m     = $search_startyear  = $search_endyear  = date('Y');
-        $search_startmonth_m    = $search_startmonth = $search_endmonth = date('m');
-        $search_startday        = $search_endday     = date('d');
+        $search_startmonth_m    = $search_startmonth = $search_endmonth = date('j');
+        $search_startday        = $search_endday     = date('n');
 
         return compact($this->arrSearchForm1, $this->arrSearchForm2);
     }

--- a/tests/class/fixtures/FixtureGenerator.php
+++ b/tests/class/fixtures/FixtureGenerator.php
@@ -412,6 +412,12 @@ class FixtureGenerator
             }
         }
 
+        if (empty($result)) {
+            // カテゴリが生成されなかったら生成しておく
+            $id = $objQuery->nextVal('dtb_category_category_id');
+            $result[] = $this->createCategory($id, 0, 1);
+        }
+
         return $result;
     }
 

--- a/tests/class/fixtures/FixtureGenerator.php
+++ b/tests/class/fixtures/FixtureGenerator.php
@@ -646,12 +646,16 @@ class FixtureGenerator
         $order_id = $this->objQuery->nextVal('dtb_order_order_id');
 
         if (empty($product_class_ids)) {
+            $where = 'product_type_id = 1 AND del_flg = 0 AND EXISTS (SELECT * FROM dtb_products WHERE del_flg = 0 AND product_id = dtb_products_class.product_id)';
+            if ($this->objQuery->count('dtb_products_class', $where) < 1) {
+                $this->createProduct();
+            }
             // 既存の商品規格から選択する
             $this->objQuery->setLimit(3);
             $product_class_ids = $this->objQuery->getCol(
                 'product_class_id',
                 'dtb_products_class',
-                'product_type_id = 1 AND del_flg = 0 AND EXISTS (SELECT * FROM dtb_products WHERE del_flg = 0 AND product_id = dtb_products_class.product_id)');
+                $where);
         }
 
         $orderDetails = array_map(function ($product_class_id) use ($order_id) {

--- a/tests/class/plugin/LoadClassFileChangeTest.php
+++ b/tests/class/plugin/LoadClassFileChangeTest.php
@@ -9,10 +9,6 @@ class LoadClassFileChangeTest extends Common_TestCase
     {
         parent::setUp();
         $this->createPlugin();
-        if (PHP_VERSION_ID < 70200) {
-            $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance();
-            $objPlugin->load();
-        }
     }
 
     protected function tearDown()


### PR DESCRIPTION
<img width="843" alt="image" src="https://user-images.githubusercontent.com/815715/61515958-cfa67e00-aa3e-11e9-9ecc-c2dac535d8c4.png">


- セレクトボックスは先頭ゼロ埋めされていないが、初期値は先頭ゼロ付きで渡っていた
- #285 の後にマージお願いします
- 売上集計の codeception 追加
  - Travis CI の PHP5.5 では FreeType が使用できない模様なので、 ImageTTFText 関数が使用できない場合はスキップ