### PR TITLE
パスワードの文字列強化

### DIFF
--- a/ctests/acceptance/EntryCept.php
+++ b/ctests/acceptance/EntryCept.php
@@ -5,6 +5,7 @@ $faker = Codeception\Util\Fixtures::get('faker');
 $I->resetEmails();
 
 $new_email = microtime(true).'.'.$faker->safeEmail;
+$password = $faker->password(8, 100);
 
 $I->wantTo('会員登録が正常にできるかを確認する');
 $I->amOnPage('/entry/kiyaku.php');
@@ -29,8 +30,8 @@ $form = [
     'tel03' => '111',
     'email' => $new_email,
     'email02' => $new_email,
-    'password' => 'password',
-    'password02' => 'password',
+    'password' => $password,
+    'password02' => $password,
     'sex' => (string) $faker->numberBetween(1, 2),
     'reminder' => (string) $faker->numberBetween(1, 7),
     'reminder_answer' => $faker->word,

--- a/ctests/acceptance/EntryCept.php
+++ b/ctests/acceptance/EntryCept.php
@@ -5,7 +5,7 @@ $faker = Codeception\Util\Fixtures::get('faker');
 $I->resetEmails();
 
 $new_email = microtime(true).'.'.$faker->safeEmail;
-$password = $faker->password(8, 100);
+$password = $faker->password(8, 100).'1';
 
 $I->wantTo('会員登録が正常にできるかを確認する');
 $I->amOnPage('/entry/kiyaku.php');

--- a/data/Smarty/templates/admin/system/input.tpl
+++ b/data/Smarty/templates/admin/system/input.tpl
@@ -71,7 +71,7 @@ self.moveTo(20,20);self.focus();
                 <!--{if $arrErr.password}--><span class="attention"><!--{$arrErr.password}--><!--{$arrErr.password02}--></span><!--{/if}-->
                 <input type="password" name="password" size="20" class="box20" value="<!--{$arrForm.password}-->" onfocus="<!--{$tpl_onfocus}-->" maxlength="<!--{$smarty.const.STEXT_LEN}-->" style="<!--{$arrErr.password|sfGetErrorColor}-->" />
                 <span class="attention">※必須入力</span><br />
-                ※半角英数字<!--{$smarty.const.ID_MIN_LEN}-->～<!--{$smarty.const.ID_MAX_LEN}-->文字（記号可）
+                ※半角英数字<!--{$smarty.const.PASSWORD_MIN_LEN}-->～<!--{$smarty.const.PASSWORD_MAX_LEN}-->文字（記号可）
                 <br />
                 <input type="password" name="password02" size="20" class="box20" value="<!--{$arrForm.password02}-->" onfocus="<!--{$tpl_onfocus}-->" maxlength="<!--{$smarty.const.STEXT_LEN}-->" style="<!--{$arrErr.password02|sfGetErrorColor}-->" />
                 <p><span class="attention mini">確認のために2度入力してください。</span></p>

--- a/data/class/SC_CheckError.php
+++ b/data/class/SC_CheckError.php
@@ -862,6 +862,33 @@ class SC_CheckError
         }
     }
 
+    /**
+     * パスワードに使用可能な文字列のチェック
+     *
+     * 半角英数字をそれぞれ1種類以上含む8文字以上100文字以下の文字列ではない場合エラーとする
+     *
+     * @param array $value $value[0] = 項目名 $value[1] = チェック対象のパスワード文字列
+     */
+    public function PASSWORD_CHAR_CHECK($value)
+    {
+        $disp_name = $value[0];
+        $keyname = $value[1];
+
+        if (isset($this->arrErr[$keyname])) {
+            return;
+        }
+
+        $this->createParam($value);
+
+        $input_var = $this->arrParam[$keyname];
+        // see https://qiita.com/mpyw/items/886218e7b418dfed254b
+        $pattern = '/\A(?=\d{0,99}+[a-z])(?=[a-z]{0,99}+\d)[a-z\d]{8,100}+\z/i';
+        if (strlen($input_var) > 0 && !preg_match($pattern, $input_var)) {
+            $this->arrErr[$keyname] =
+                "※ {$disp_name}は英数字をそれぞれ1種類使用し、8文字以上で入力してください。<br />";
+        }
+    }
+
     /*　必須選択の判定　*/
     // 入力値で0が許されない場合エラーを返す
     // value[0] = 項目名 value[1] = 判定対象

--- a/data/class/SC_CheckError.php
+++ b/data/class/SC_CheckError.php
@@ -865,12 +865,16 @@ class SC_CheckError
     /**
      * パスワードに使用可能な文字列のチェック
      *
-     * 半角英数字をそれぞれ1種類以上含む8文字以上100文字以下の文字列ではない場合エラーとする
+     * 半角英数字をそれぞれ1種類以上含む PASSWORD_MIN_LEN 文字以上 PASSWORD_MAX_LEN 文字以下の文字列ではない場合エラーとする
+     * PASSWORD_MIN_LEN が8未満の場合は E_USER_WARNING を出力する
      *
      * @param array $value $value[0] = 項目名 $value[1] = チェック対象のパスワード文字列
      */
     public function PASSWORD_CHAR_CHECK($value)
     {
+        if (PASSWORD_MIN_LEN < 8) {
+            trigger_error('PASSWORD_MIN_LEN が8未満に設定されています。', E_USER_WARNING);
+        }
         $disp_name = $value[0];
         $keyname = $value[1];
 
@@ -882,10 +886,10 @@ class SC_CheckError
 
         $input_var = $this->arrParam[$keyname];
         // see https://qiita.com/mpyw/items/886218e7b418dfed254b
-        $pattern = '/\A(?=\d{0,99}+[a-z])(?=[a-z]{0,99}+\d)[a-z\d]{8,100}+\z/i';
+        $pattern = '/\A(?=.*?[a-z])(?=.*?\d)[!-~]{'.PASSWORD_MIN_LEN.','.PASSWORD_MAX_LEN.'}+\z/i';
         if (strlen($input_var) > 0 && !preg_match($pattern, $input_var)) {
             $this->arrErr[$keyname] =
-                "※ {$disp_name}は英数字をそれぞれ1種類使用し、8文字以上で入力してください。<br />";
+                "※ {$disp_name}は英数字をそれぞれ1種類使用し、".PASSWORD_MIN_LEN."文字以上で入力してください。<br />";
         }
     }
 

--- a/data/class/SC_FormParam.php
+++ b/data/class/SC_FormParam.php
@@ -206,6 +206,7 @@ class SC_FormParam
                     case 'NUM_CHECK':
                     case 'EMAIL_CHECK':
                     case 'EMAIL_CHAR_CHECK':
+                    case 'PASSWORD_CHAR_CHECK':
                     case 'ALNUM_CHECK':
                     case 'GRAPH_CHECK':
                     case 'KANA_CHECK':

--- a/data/class/helper/SC_Helper_Customer.php
+++ b/data/class/helper/SC_Helper_Customer.php
@@ -430,7 +430,7 @@ class SC_Helper_Customer
      */
     public function sfCustomerRegisterParam(&$objFormParam, $isAdmin = false, $is_mypage = false, $prefix = '')
     {
-        $objFormParam->addParam('パスワード', $prefix . 'password', PASSWORD_MAX_LEN, '', array('EXIST_CHECK', 'SPTAB_CHECK', 'GRAPH_CHECK'));
+        $objFormParam->addParam('パスワード', $prefix . 'password', PASSWORD_MAX_LEN, '', array('EXIST_CHECK', 'SPTAB_CHECK', 'PASSWORD_CHAR_CHECK'));
         $objFormParam->addParam('パスワード確認用の質問の答え', $prefix . 'reminder_answer', STEXT_LEN, '', array('EXIST_CHECK', 'SPTAB_CHECK', 'MAX_LENGTH_CHECK'));
         $objFormParam->addParam('パスワード確認用の質問', $prefix . 'reminder', STEXT_LEN, 'n', array('EXIST_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK'));
         $objFormParam->addParam('性別', $prefix . 'sex', INT_LEN, 'n', array('EXIST_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK'));
@@ -443,7 +443,7 @@ class SC_Helper_Customer
 
         if (SC_Display_Ex::detectDevice() !== DEVICE_TYPE_MOBILE) {
             $objFormParam->addParam('メールアドレス', $prefix . 'email', null, 'a', array('NO_SPTAB', 'EXIST_CHECK', 'EMAIL_CHECK', 'SPTAB_CHECK', 'EMAIL_CHAR_CHECK'));
-            $objFormParam->addParam('パスワード(確認)', $prefix . 'password02', PASSWORD_MAX_LEN, '', array('EXIST_CHECK', 'SPTAB_CHECK', 'GRAPH_CHECK'), '', false);
+            $objFormParam->addParam('パスワード(確認)', $prefix . 'password02', PASSWORD_MAX_LEN, '', array('EXIST_CHECK', 'SPTAB_CHECK', 'PASSWORD_CHAR_CHECK'), '', false);
             if (!$isAdmin) {
                 $objFormParam->addParam('メールアドレス(確認)', $prefix . 'email02', null, 'a', array('NO_SPTAB', 'EXIST_CHECK', 'EMAIL_CHECK', 'SPTAB_CHECK', 'EMAIL_CHAR_CHECK'), '', false);
             }

--- a/data/class/pages/admin/LC_Page_Admin_Index.php
+++ b/data/class/pages/admin/LC_Page_Admin_Index.php
@@ -100,7 +100,7 @@ class LC_Page_Admin_Index extends LC_Page_Admin_Ex
     public function lfInitParam(&$objFormParam)
     {
         $objFormParam->addParam('ID', 'login_id', ID_MAX_LEN, '', array('EXIST_CHECK', 'ALNUM_CHECK' ,'MAX_LENGTH_CHECK'));
-        $objFormParam->addParam('PASSWORD', 'password', ID_MAX_LEN, '', array('EXIST_CHECK', 'GRAPH_CHECK', 'MAX_LENGTH_CHECK'));
+        $objFormParam->addParam('PASSWORD', 'password', PASSWORD_MAX_LEN, '', array('EXIST_CHECK', 'GRAPH_CHECK', 'MAX_LENGTH_CHECK'));
     }
 
     /**

--- a/data/class/pages/admin/system/LC_Page_Admin_System_Input.php
+++ b/data/class/pages/admin/system/LC_Page_Admin_System_Input.php
@@ -189,8 +189,8 @@ class LC_Page_Admin_System_Input extends LC_Page_Admin_Ex
             $objFormParam->addParam('パスワード', 'password', '', '', array('EXIST_CHECK'));
             $objFormParam->addParam('パスワード(確認)', 'password02', '', '', array('EXIST_CHECK'));
         } else {
-            $objFormParam->addParam('パスワード', 'password', '', '', array('EXIST_CHECK', 'GRAPH_CHECK'));
-            $objFormParam->addParam('パスワード(確認)', 'password02', '', '', array('EXIST_CHECK', 'GRAPH_CHECK'));
+            $objFormParam->addParam('パスワード', 'password', '', '', array('EXIST_CHECK', 'PASSWORD_CHAR_CHECK'));
+            $objFormParam->addParam('パスワード(確認)', 'password02', '', '', array('EXIST_CHECK', 'PASSWORD_CHAR_CHECK'));
         }
         $objFormParam->addParam('権限', 'authority', INT_LEN, '', array('EXIST_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK'));
         $objFormParam->addParam('稼働/非稼働', 'work', INT_LEN, '', array('EXIST_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK'));

--- a/data/class/pages/admin/system/LC_Page_Admin_System_Input.php
+++ b/data/class/pages/admin/system/LC_Page_Admin_System_Input.php
@@ -216,10 +216,10 @@ class LC_Page_Admin_System_Input extends LC_Page_Admin_Ex
         // ログインID・パスワードの文字数チェック
         $objErr = new SC_CheckError_Ex();
         if ($mode == 'new') {
-            $objErr->doFunc(array('パスワード', 'password', ID_MIN_LEN, ID_MAX_LEN), array('NUM_RANGE_CHECK'));
+            $objErr->doFunc(array('パスワード', 'password', PASSWORD_MIN_LEN, PASSWORD_MAX_LEN), array('NUM_RANGE_CHECK'));
             $objErr->doFunc(array('ログインID', 'login_id', ID_MIN_LEN, ID_MAX_LEN), array('NUM_RANGE_CHECK'));
         } elseif ($mode == 'edit') {
-            $objErr->doFunc(array('パスワード', 'password', ID_MIN_LEN, ID_MAX_LEN), array('SPTAB_CHECK', 'NUM_RANGE_CHECK'));
+            $objErr->doFunc(array('パスワード', 'password', PASSWORD_MIN_LEN, PASSWORD_MAX_LEN), array('SPTAB_CHECK', 'NUM_RANGE_CHECK'));
             $objErr->doFunc(array('ログインID', 'login_id', ID_MIN_LEN, ID_MAX_LEN), array('SPTAB_CHECK', 'NUM_RANGE_CHECK'));
         }
         $objErr->doFunc(array('パスワード', 'パスワード(確認)', 'password', 'password02'), array('EQUAL_CHECK'));

--- a/data/mtb_constants_init.php
+++ b/data/mtb_constants_init.php
@@ -255,9 +255,9 @@ define('TEL_ITEM_LEN', 6);
 /** 電話番号総数 */
 define('TEL_LEN', 12);
 /** フロント画面用：パスワードの最小文字数 */
-define('PASSWORD_MIN_LEN', 4);
+define('PASSWORD_MIN_LEN', 8);
 /** フロント画面用：パスワードの最大文字数 */
-define('PASSWORD_MAX_LEN', STEXT_LEN);
+define('PASSWORD_MAX_LEN', SMTEXT_LEN);
 /** 検査数値用桁数(INT) */
 define('INT_LEN', 9);
 /** クレジットカードの文字数 (*モジュールで使用) */

--- a/html/install/index.php
+++ b/html/install/index.php
@@ -701,8 +701,8 @@ function lfInitWebParam($objWebParam)
 
     $objWebParam->addParam('店名', 'shop_name', MTEXT_LEN, '', array('EXIST_CHECK', 'MAX_LENGTH_CHECK'), $shop_name);
     $objWebParam->addParam('管理者：メールアドレス', 'admin_mail', null, '', array('EXIST_CHECK', 'EMAIL_CHECK', 'EMAIL_CHAR_CHECK'), $admin_mail);
-    $objWebParam->addParam('管理者：ログインID', 'login_id', ID_MAX_LEN, '', array('EXIST_CHECK', 'SPTAB_CHECK', 'ALNUM_CHECK'));
-    $objWebParam->addParam('管理者：パスワード', 'login_pass', ID_MAX_LEN, '', array('EXIST_CHECK', 'SPTAB_CHECK', 'ALNUM_CHECK'));
+    $objWebParam->addParam('管理者：ログインID', 'login_id', ID_MAX_LEN, '', array('EXIST_CHECK', 'SPTAB_CHECK', 'GRAPH_CHECK'));
+    $objWebParam->addParam('管理者：パスワード', 'login_pass', PASSWORD_MAX_LEN, '', array('EXIST_CHECK', 'SPTAB_CHECK', 'PASSWORD_CHAR_CHECK'));
     $objWebParam->addParam('管理機能：ディレクトリ', 'admin_dir', ID_MAX_LEN, 'a', array('EXIST_CHECK', 'SPTAB_CHECK', 'ALNUM_CHECK'), $oldAdminDir);
     $objWebParam->addParam('管理機能：SSL制限', 'admin_force_ssl', 1, 'n', array('SPTAB_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK'), $admin_force_ssl);
     $objWebParam->addParam('管理機能：IP制限', 'admin_allow_hosts', LTEXT_LEN, 'an', array('IP_CHECK', 'MAX_LENGTH_CHECK'), $admin_allow_hosts);
@@ -782,7 +782,7 @@ function lfCheckWebError($objWebParam)
     $objErr->doFunc(array('管理者：ログインID', 'login_id', ID_MIN_LEN, ID_MAX_LEN), array('SPTAB_CHECK', 'NUM_RANGE_CHECK'));
 
     // パスワードのチェック
-    $objErr->doFunc(array('管理者：パスワード', 'login_pass', ID_MIN_LEN, ID_MAX_LEN), array('SPTAB_CHECK', 'NUM_RANGE_CHECK'));
+    $objErr->doFunc(array('管理者：パスワード', 'login_pass', PASSWORD_MIN_LEN, PASSWORD_MAX_LEN), array('SPTAB_CHECK', 'NUM_RANGE_CHECK'));
 
     // 管理機能ディレクトリのチェック
     $objErr->doFunc(array('管理機能：ディレクトリ', 'admin_dir', ID_MIN_LEN, ID_MAX_LEN), array('SPTAB_CHECK', 'NUM_RANGE_CHECK'));

--- a/html/install/sql/insert_data.sql
+++ b/html/install/sql/insert_data.sql
@@ -1170,8 +1170,8 @@ INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('ZIP01_LEN', '3', 20
 INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('ZIP02_LEN', '4', 201, '郵便番号2');
 INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('TEL_ITEM_LEN', '6', 202, '電話番号各項目制限');
 INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('TEL_LEN', '12', 203, '電話番号総数');
-INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('PASSWORD_MIN_LEN', '4', 204, 'フロント画面用：パスワードの最小文字数');
-INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('PASSWORD_MAX_LEN', 'STEXT_LEN', 205, 'フロント画面用：パスワードの最大文字数');
+INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('PASSWORD_MIN_LEN', '8', 204, 'フロント画面用：パスワードの最小文字数');
+INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('PASSWORD_MAX_LEN', 'SMTEXT_LEN', 205, 'フロント画面用：パスワードの最大文字数');
 INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('INT_LEN', '9', 206, '検査数値用桁数(INT)');
 INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('CREDIT_NO_LEN', '4', 207, 'クレジットカードの文字数 (*モジュールで使用)');
 INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('SEARCH_CATEGORY_LEN', '18', 208, '検索カテゴリ最大表示文字数(byte)');

--- a/html/install/templates/step1.tpl
+++ b/html/install/templates/step1.tpl
@@ -75,7 +75,7 @@ $(function() {
                     </td>
                 </tr>
                 <tr>
-                    <th>ログインID<span class="attention">※</span><br/>半角英数字<!--{$smarty.const.ID_MIN_LEN}-->～<!--{$smarty.const.ID_MAX_LEN}-->文字</th>
+                    <th>ログインID<span class="attention">※</span><br/>半角英数字記号<!--{$smarty.const.ID_MIN_LEN}-->～<!--{$smarty.const.ID_MAX_LEN}-->文字</th>
                     <td>
                     <!--{assign var=key value="login_id"}-->
                     <span class="attention"><!--{$arrErr[$key]}--></span>
@@ -84,7 +84,7 @@ $(function() {
                     </td>
                 </tr>
                 <tr>
-                    <th>パスワード<span class="attention">※</span><br/>半角英数字<!--{$smarty.const.ID_MIN_LEN}-->～<!--{$smarty.const.ID_MAX_LEN}-->文字</th>
+                    <th>パスワード<span class="attention">※</span><br/>半角英数字記号<!--{$smarty.const.PASSWORD_MIN_LEN}-->～<!--{$smarty.const.PASSWORD_MAX_LEN}-->文字</th>
                     <td>
                     <!--{assign var=key value="login_pass"}-->
                     <span class="attention"><!--{$arrErr[$key]}--></span>

--- a/tests/class/SC_CheckError/SC_CheckError_PASSWORD_CHAR_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_PASSWORD_CHAR_CHECKTest.php
@@ -1,0 +1,94 @@
+<?php
+
+class SC_CheckError_PASSWORD_CHAR_CHECKTest extends SC_CheckError_AbstractTestCase
+{
+    /** @var Faker\Generator */
+    protected $faker;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->target_func = 'PASSWORD_CHAR_CHECK';
+        $this->faker = Faker\Factory::create('ja_JP');
+    }
+
+    public function testPASSWORD_CHAR_CHECK()
+    {
+        $this->arrForm = [self::FORM_NAME => 'aaaa1111'];
+        $this->expected = '';
+
+        $this->scenario();
+        $this->verify();
+    }
+
+    public function testPASSWORD_CHAR_CHECKWithSymbol()
+    {
+        $this->arrForm = [self::FORM_NAME => 'aaaa.1111'];
+        $this->expected = '';
+
+        $this->scenario();
+        $this->verify();
+    }
+
+    public function testPASSWORD_CHAR_CHECKWithEmpty()
+    {
+        $this->arrForm = [self::FORM_NAME => ''];
+        $this->expected = '';
+
+        $this->scenario();
+        $this->verify();
+    }
+
+    public function testPASSWORD_CHAR_CHECKWithNull()
+    {
+        $this->arrForm = [self::FORM_NAME => null];
+        $this->expected = '';
+
+        $this->scenario();
+        $this->verify();
+    }
+
+    public function testPASSWORD_CHAR_CHECKWithFaker()
+    {
+        $this->arrForm = [
+            self::FORM_NAME => $this->faker->password(8, 100)
+        ];
+        $this->expected = '';
+        $this->scenario();
+        $this->verify($this->arrForm[self::FORM_NAME].' はパスワードに使用できない文字列です');
+    }
+
+    public function testPASSWORD_CHAR_CHECKWithAlphabetOnly()
+    {
+        $this->arrForm = [
+            self::FORM_NAME => 'password'
+        ];
+        $this->expected = '※ PASSWORD_CHAR_CHECKは英数字をそれぞれ1種類使用し、8文字以上で入力してください。<br />';
+
+        $this->scenario();
+        $this->verify();
+    }
+
+    public function testPASSWORD_CHAR_CHECKWithNumberOnly()
+    {
+        $this->arrForm = [
+            self::FORM_NAME => '12345678'
+        ];
+        $this->expected = '※ PASSWORD_CHAR_CHECKは英数字をそれぞれ1種類使用し、8文字以上で入力してください。<br />';
+
+        $this->scenario();
+        $this->verify();
+    }
+
+    public function testPASSWORD_CHAR_CHECKWithMinute()
+    {
+        $this->arrForm = [
+            self::FORM_NAME => $this->faker->password(6, 7)
+        ];
+        $this->expected = '※ PASSWORD_CHAR_CHECKは英数字をそれぞれ1種類使用し、8文字以上で入力してください。<br />';
+
+        $this->scenario();
+        $this->verify();
+    }
+}
+

--- a/tests/class/SC_CheckError/SC_CheckError_PASSWORD_CHAR_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_PASSWORD_CHAR_CHECKTest.php
@@ -51,7 +51,7 @@ class SC_CheckError_PASSWORD_CHAR_CHECKTest extends SC_CheckError_AbstractTestCa
     public function testPASSWORD_CHAR_CHECKWithFaker()
     {
         $this->arrForm = [
-            self::FORM_NAME => $this->faker->password(8, 100)
+            self::FORM_NAME => $this->faker->password(8, 100).'1'
         ];
         $this->expected = '';
         $this->scenario();

--- a/tests/class/plugin/LoadClassFileChangeTest.php
+++ b/tests/class/plugin/LoadClassFileChangeTest.php
@@ -9,10 +9,6 @@ class LoadClassFileChangeTest extends Common_TestCase
     {
         parent::setUp();
         $this->createPlugin();
-        if (PHP_VERSION_ID < 70200) {
-            $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance();
-            $objPlugin->load();
-        }
     }
 
     protected function tearDown()


### PR DESCRIPTION
- 半角英数字をそれぞれ1種類以上含む8文字以上100文字以下の文字列ではない場合エラーとする
- 記号を含めることも可能
- インストーラのログインID, パスワード設定に記号を含められないのを修正
- 管理画面ユーザーのパスワード桁数を PASSWORD_MIN_LEN, PASSWORD_MAX_LEN に変更
- PASSWORD_MIN_LEN が8未満の場合は E_USER_WARNING を出力するよう修正
- #292 