### PR TITLE
frontparts/logincheck.php に直接アクセスするとシステムエラーになるのを修正

### DIFF
--- a/data/class/pages/frontparts/LC_Page_FrontParts_LoginCheck.php
+++ b/data/class/pages/frontparts/LC_Page_FrontParts_LoginCheck.php
@@ -200,6 +200,7 @@ class LC_Page_FrontParts_LoginCheck extends LC_Page_Ex
                 break;
         }
 
+        SC_Utils_Ex::sfDispSiteError(CUSTOMER_ERROR);
     }
 
     /**


### PR DESCRIPTION
frontparts/logincheck.php にパラメータ無しで直接アクセスすると、システムエラーになる

```
2019/08/07 19:21:17 [/frontparts/login_check.php] Fatal error(E_ERROR): Uncaught  --> Smarty: Source: Missing  name <-- 
  thrown on [/path/to/eccube-2_13/data/vendor/smarty/smarty/libs/sysplugins/smarty_template_source.php(167)] from
```

`site_main.tpl` に渡す `$tpl_mainpage` が空なので、 [Smarty の include](https://www.smarty.net/docs/ja/language.function.include.tpl) がエラーになってしまう。

直接アクセスした場合は、`CUSTOMER_ERROR` 画面を表示するように修正