### PR TITLE
商品別税率設定のテストを動作するよう修正

### DIFF
--- a/data/class/helper/SC_Helper_TaxRule.php
+++ b/data/class/helper/SC_Helper_TaxRule.php
@@ -116,9 +116,11 @@ class SC_Helper_TaxRule
      * @param int $product_class_id 商品規格ID
      * @param int $pref_id 都道府県ID
      * @param int $country_id 国ID
-     * @return integer 税設定情報
+     * @param int $option_product_tax_rule 商品別税率を有効にする場合 1, 無効の場合 0
+     *
+     * @return array 税設定情報
      */
-    public static function getTaxRule($product_id = 0, $product_class_id = 0, $pref_id = 0, $country_id = 0)
+    public static function getTaxRule($product_id = 0, $product_class_id = 0, $pref_id = 0, $country_id = 0, $option_product_tax_rule = OPTION_PRODUCT_TAX_RULE)
     {
         // 複数回呼出があるのでキャッシュ化
         static $data_c = array();
@@ -130,7 +132,7 @@ class SC_Helper_TaxRule
         $country_id = $country_id > 0 ? $country_id : 0;
 
         // 一覧画面の速度向上のため商品単位税率設定がOFFの時はキャッシュキーを丸めてしまう
-        if (OPTION_PRODUCT_TAX_RULE == 1) {
+        if ($option_product_tax_rule == 1) {
             $cache_key = "$product_id,$product_class_id,$pref_id,$country_id";
         } else {
             $cache_key = "$pref_id,$country_id";
@@ -167,7 +169,7 @@ class SC_Helper_TaxRule
             $cols = '*';
 
             // 商品税率有無設定により分岐
-            if (OPTION_PRODUCT_TAX_RULE == 1) {
+            if ($option_product_tax_rule == 1) {
                 $where = '
                         (
                             (product_id = 0 OR product_id = ?)

--- a/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_TestBase.php
+++ b/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_TestBase.php
@@ -31,6 +31,11 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Helper_TaxRule_TestBase extends Common_TestCase
 {
 
+    /**
+     * @var SC_Helper_TaxRule_Ex
+     */
+    protected $objTaxRule;
+
     protected function setUp()
     {
         parent::setUp();

--- a/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_getTaxRule_OptionProductTaxRuleTest.php
+++ b/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_getTaxRule_OptionProductTaxRuleTest.php
@@ -1,17 +1,17 @@
 <?php
 
-$HOME = realpath(dirname(__FILE__)) . "/../../../..";
-// 商品別税率機能無効
-define('OPTION_PRODUCT_TAX_RULE', 1);
-require_once($HOME . "/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_TestBase.php");
-
 class SC_Helper_TaxRule_getTaxRule_OptionProductTaxRuleTest extends SC_Helper_TaxRule_TestBase
 {
+
+    /**
+     * 商品別税率有効
+     * @var int
+     */
+    const OPTION_PRODUCT_TAX_RULE_ENABLE = 1;
 
     protected function setUp()
     {
         parent::setUp();
-        $this->markTestIncomplete('定数の再定義テストは実装されていません');
         $this->objTaxRule = new SC_Helper_TaxRule_Ex();
         $this->setUpTax();
     }
@@ -28,18 +28,6 @@ class SC_Helper_TaxRule_getTaxRule_OptionProductTaxRuleTest extends SC_Helper_Ta
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
-    public function 定数が正しく設定されているかのテスト()
-    {
-        $this->expected = 1;
-        $this->actual = constant('OPTION_PRODUCT_TAX_RULE');
-        $this->verify();
-    }
-
-    /**
-     * @test
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
     public function 引数が空の場合税率設定で設定かつ適用日時内の最新の値が返される()
     {
         $this->expected = array(
@@ -50,7 +38,7 @@ class SC_Helper_TaxRule_getTaxRule_OptionProductTaxRuleTest extends SC_Helper_Ta
             'del_flg' => '0'
         );
 
-        $return = $this->objTaxRule->getTaxRule();
+        $return = $this->objTaxRule->getTaxRule(0, 0, 0, 0, self::OPTION_PRODUCT_TAX_RULE_ENABLE);
         $this->actual = array(
             'apply_date' => $return['apply_date'],
             'tax_rate' => $return['tax_rate'],
@@ -77,7 +65,7 @@ class SC_Helper_TaxRule_getTaxRule_OptionProductTaxRuleTest extends SC_Helper_Ta
             'del_flg' => '0'
         );
 
-        $return = $this->objTaxRule->getTaxRule(1000);
+        $return = $this->objTaxRule->getTaxRule(1000, 0, 0, 0, self::OPTION_PRODUCT_TAX_RULE_ENABLE);
         $this->actual = array(
             'apply_date' => $return['apply_date'],
             'tax_rate' => $return['tax_rate'],
@@ -104,7 +92,7 @@ class SC_Helper_TaxRule_getTaxRule_OptionProductTaxRuleTest extends SC_Helper_Ta
             'del_flg' => '0'
         );
 
-        $return = $this->objTaxRule->getTaxRule(1000, 2000);
+        $return = $this->objTaxRule->getTaxRule(1000, 2000, 0, 0, self::OPTION_PRODUCT_TAX_RULE_ENABLE);
         $this->actual = array(
             'apply_date' => $return['apply_date'],
             'tax_rate' => $return['tax_rate'],
@@ -131,7 +119,7 @@ class SC_Helper_TaxRule_getTaxRule_OptionProductTaxRuleTest extends SC_Helper_Ta
             'del_flg' => '0'
         );
 
-        $return = $this->objTaxRule->getTaxRule(0, 2000);
+        $return = $this->objTaxRule->getTaxRule(0, 2000, 0, 0, self::OPTION_PRODUCT_TAX_RULE_ENABLE);
         $this->actual = array(
             'apply_date' => $return['apply_date'],
             'tax_rate' => $return['tax_rate'],


### PR DESCRIPTION
- 定数ではなく `SC_Helper_TaxRule::getTaxRule()` の引数で設定できるよう修正