### PR TITLE
商品規格ごとの税率設定を削除

### DIFF
--- a/data/Smarty/templates/admin/products/confirm.tpl
+++ b/data/Smarty/templates/admin/products/confirm.tpl
@@ -123,14 +123,6 @@
                     <!--{if strlen($arrForm.price02) >= 1}--><!--{$arrForm.price02|h}--> 円<!--{/if}-->
                 </td>
             </tr>
-            <!--{if $smarty.const.OPTION_PRODUCT_TAX_RULE ==1}-->
-            <tr>
-                <th>消費税率</th>
-                <td>
-                    <!--{if strlen($arrForm.tax_rate) >= 1}--><!--{$arrForm.tax_rate|h}--> %<!--{/if}-->
-                </td>
-            </tr>
-            <!--{/if}-->
             <tr>
                 <th>在庫数</th>
                 <td>
@@ -139,6 +131,14 @@
                     <!--{else}-->
                         <!--{$arrForm.stock|h}-->
                     <!--{/if}-->
+                </td>
+            </tr>
+        <!--{/if}-->
+        <!--{if $smarty.const.OPTION_PRODUCT_TAX_RULE ==1}-->
+            <tr>
+                <th>消費税率</th>
+                <td>
+                    <!--{if strlen($arrForm.tax_rate) >= 1}--><!--{$arrForm.tax_rate|h}--> %<!--{/if}-->
                 </td>
             </tr>
         <!--{/if}-->

--- a/data/Smarty/templates/admin/products/product.tpl
+++ b/data/Smarty/templates/admin/products/product.tpl
@@ -213,6 +213,15 @@
                 <span class="attention"> (半角数字で入力)</span>
             </td>
         </tr>
+        <tr>
+            <th>在庫数<span class="attention"> *</span></th>
+            <td>
+                <span class="attention"><!--{$arrErr.stock}--></span>
+                <input type="text" name="stock" value="<!--{$arrForm.stock|h}-->" size="6" class="box6" maxlength="<!--{$smarty.const.AMOUNT_LEN}-->" style="<!--{if $arrErr.stock != ""}-->background-color: <!--{$smarty.const.ERR_COLOR}-->;<!--{/if}-->"/>
+                <input type="checkbox" name="stock_unlimited" value="1" <!--{if $arrForm.stock_unlimited == "1"}-->checked<!--{/if}--> onclick="eccube.checkStockLimit('<!--{$smarty.const.DISABLED_RGB}-->');"/>無制限
+            </td>
+        </tr>
+        <!--{/if}-->
         <!--{if $smarty.const.OPTION_PRODUCT_TAX_RULE ==1}-->
         <tr>
             <th>消費税率<span class="attention"> *</span></th>
@@ -220,15 +229,6 @@
                 <span class="attention"><!--{$arrErr.tax_rate}--></span>
                 <input type="text" name="tax_rate" value="<!--{$arrForm.tax_rate|h}-->" size="6" class="box6" maxlength="<!--{$smarty.const.PERCENTAGE_LEN}-->" style="<!--{if $arrErr.tax_rate != ""}-->background-color: <!--{$smarty.const.ERR_COLOR}-->;<!--{/if}-->"/>%
                 <span class="attention">(半角数字で入力)</span>
-            </td>
-        </tr>
-        <!--{/if}-->
-        <tr>
-            <th>在庫数<span class="attention"> *</span></th>
-            <td>
-                <span class="attention"><!--{$arrErr.stock}--></span>
-                <input type="text" name="stock" value="<!--{$arrForm.stock|h}-->" size="6" class="box6" maxlength="<!--{$smarty.const.AMOUNT_LEN}-->" style="<!--{if $arrErr.stock != ""}-->background-color: <!--{$smarty.const.ERR_COLOR}-->;<!--{/if}-->"/>
-                <input type="checkbox" name="stock_unlimited" value="1" <!--{if $arrForm.stock_unlimited == "1"}-->checked<!--{/if}--> onclick="eccube.checkStockLimit('<!--{$smarty.const.DISABLED_RGB}-->');"/>無制限
             </td>
         </tr>
         <!--{/if}-->

--- a/data/Smarty/templates/admin/products/product_class.tpl
+++ b/data/Smarty/templates/admin/products/product_class.tpl
@@ -203,9 +203,6 @@
                 <th>在庫数<span class="attention">*</span></th>
                 <th><!--{$smarty.const.NORMAL_PRICE_TITLE}-->(円)</th>
                 <th><!--{$smarty.const.SALE_PRICE_TITLE}-->(円)<span class="attention">*</span></th>
-                <!--{if $smarty.const.OPTION_PRODUCT_TAX_RULE}-->
-                <th>消費税率(%)<span class="attention">*</span></th>
-                <!--{/if}-->
                 <th>商品種別<span class="attention">*</span></th>
                 <th>ダウンロード<br />ファイル名<span class="red"><br />上限<!--{$smarty.const.STEXT_LEN}-->文字</span></th>
                 <th>ダウンロード商品用<br />ファイル</th>
@@ -276,15 +273,6 @@
                         <!--{/if}-->
                         <input type="text" name="<!--{$key}-->[<!--{$index}-->]" value="<!--{$arrForm[$key].value[$index]|h}-->" size="6" class="box6" maxlength="<!--{$arrForm[$key].length}-->" <!--{if $arrErr[$key][$index] != ""}--><!--{sfSetErrorStyle}--><!--{/if}--> id="<!--{$key}-->_<!--{$index}-->" />
                     </td>
-                    <!--{if $smarty.const.OPTION_PRODUCT_TAX_RULE}-->
-                    <td class="center">
-                        <!--{assign var=key value="tax_rate"}-->
-                        <!--{if $arrErr[$key][$index]}-->
-                            <span class="attention"><!--{$arrErr[$key][$index]}--></span>
-                        <!--{/if}-->
-                        <input type="text" name="<!--{$key}-->[<!--{$index}-->]" value="<!--{$arrForm[$key].value[$index]|h}-->" size="6" class="box6" maxlength="<!--{$arrForm[$key].length}-->" <!--{if $arrErr[$key][$index] != ""}--><!--{sfSetErrorStyle}--><!--{/if}--> id="<!--{$key}-->_<!--{$index}-->" />
-                    </td>
-                    <!--{/if}-->
                     <td class="class-product-type">
                         <!--{assign var=key value="product_type_id"}-->
                         <!--{if $arrErr[$key][$index]}-->

--- a/data/Smarty/templates/admin/products/product_class_confirm.tpl
+++ b/data/Smarty/templates/admin/products/product_class_confirm.tpl
@@ -63,9 +63,6 @@
                     <th>在庫数</th>
                     <th><!--{$smarty.const.NORMAL_PRICE_TITLE}-->(円)</th>
                     <th><!--{$smarty.const.SALE_PRICE_TITLE}-->(円)</th>
-                    <!--{if $smarty.const.OPTION_PRODUCT_TAX_RULE}-->
-                    <th>消費税率(%)</th>
-                    <!--{/if}-->
                     <th>商品種別</th>
                     <th>ダウンロードファイル名</th>
                     <th>ダウンロード商品用ファイルアップロード</th>
@@ -94,10 +91,6 @@
                             <td class="right"><!--{$arrForm[$key].value[$index]|h}--></td>
                             <!--{assign var=key value="price02"}-->
                             <td class="right"><!--{$arrForm[$key].value[$index]|h}--></td>
-                            <!--{if $smarty.const.OPTION_PRODUCT_TAX_RULE}-->
-                            <!--{assign var=key value="tax_rate"}-->
-                            <td class="right"><!--{$arrForm[$key].value[$index]|h}--></td>
-                            <!--{/if}-->
                             <!--{assign var=key value="product_type_id"}-->
                             <td class="right">
                                 <!--{foreach from=$arrForm[$key].value[$index] item=product_type_id}-->

--- a/data/class/SC_Product.php
+++ b/data/class/SC_Product.php
@@ -295,12 +295,12 @@ __EOS__;
                 // TODO: ここでprice01,price02を税込みにしてよいのか？ _inctax を付けるべき？要検証
                 $arrClassCats2['price01']
                     = strlen($arrProductsClass['price01'])
-                    ? number_format(SC_Helper_TaxRule_Ex::sfCalcIncTax($arrProductsClass['price01'], $productId, $arrProductsClass['product_class_id']))
+                    ? number_format(SC_Helper_TaxRule_Ex::sfCalcIncTax($arrProductsClass['price01'], $productId))
                     : '';
 
                 $arrClassCats2['price02']
                     = strlen($arrProductsClass['price02'])
-                    ? number_format(SC_Helper_TaxRule_Ex::sfCalcIncTax($arrProductsClass['price02'], $productId, $arrProductsClass['product_class_id']))
+                    ? number_format(SC_Helper_TaxRule_Ex::sfCalcIncTax($arrProductsClass['price02'], $productId))
                     : '';
 
                 // ポイント
@@ -404,10 +404,10 @@ __EOS__;
 
         // 税込計算
         if (!SC_Utils_Ex::isBlank($arrProduct['price01'])) {
-            $arrProduct['price01_inctax'] = SC_Helper_TaxRule_Ex::sfCalcIncTax($arrProduct['price01'], $arrProduct['product_id'], $productClassId);
+            $arrProduct['price01_inctax'] = SC_Helper_TaxRule_Ex::sfCalcIncTax($arrProduct['price01'], $arrProduct['product_id']);
         }
         if (!SC_Utils_Ex::isBlank($arrProduct['price02'])) {
-            $arrProduct['price02_inctax'] = SC_Helper_TaxRule_Ex::sfCalcIncTax($arrProduct['price02'], $arrProduct['product_id'], $productClassId);
+            $arrProduct['price02_inctax'] = SC_Helper_TaxRule_Ex::sfCalcIncTax($arrProduct['price02'], $arrProduct['product_id']);
         }
 
         return $arrProduct;

--- a/data/class/helper/SC_Helper_TaxRule.php
+++ b/data/class/helper/SC_Helper_TaxRule.php
@@ -113,7 +113,7 @@ class SC_Helper_TaxRule
      * 現在有効な税率設定情報を返す
      *
      * @param int $product_id 商品ID
-     * @param int $product_class_id 商品規格ID
+     * @param int $product_class_id 商品規格ID(商品規格ごとの税率設定は廃止のため常に0)
      * @param int $pref_id 都道府県ID
      * @param int $country_id 国ID
      * @return integer 税設定情報
@@ -243,7 +243,7 @@ class SC_Helper_TaxRule
             // 課税規則は基本設定のものを使用
             $calc_rule = $arrRet['calc_rule'];
             // 日付は登録時点を設定
-            $apply_date = date('Y/m/d H:i:s');
+            $apply_date = 'CURRENT_TIMESTAMP';
             // 税情報を設定
             SC_Helper_TaxRule_Ex::setTaxRule($calc_rule, $tax_rate, $apply_date, NULL, $tax_adjust, $product_id, $product_class_id, $pref_id, $country_id);
         }

--- a/data/class/helper/SC_Helper_TaxRule.php
+++ b/data/class/helper/SC_Helper_TaxRule.php
@@ -117,6 +117,7 @@ class SC_Helper_TaxRule
      * @param int $pref_id 都道府県ID
      * @param int $country_id 国ID
      * @return integer 税設定情報
+     * @see https://github.com/EC-CUBE/eccube-2_13/pull/301
      */
     public static function getTaxRule($product_id = 0, $product_class_id = 0, $pref_id = 0, $country_id = 0)
     {

--- a/data/class/pages/admin/order/LC_Page_Admin_Order_Edit.php
+++ b/data/class/pages/admin/order/LC_Page_Admin_Order_Edit.php
@@ -689,9 +689,10 @@ class LC_Page_Admin_Order_Edit extends LC_Page_Admin_Order_Ex
         $totaltax = 0;
         for ($i = 0; $i < $max; $i++) {
             // 小計の計算
-            $subtotal += SC_Helper_DB_Ex::sfCalcIncTax($arrValues['price'][$i], $arrValues['tax_rate'][$i], $arrValues['tax_rule'][$i]) * $arrValues['quantity'][$i];
-            // 小計の計算
-            $totaltax += SC_Utils_Ex::sfTax($arrValues['price'][$i], $arrValues['tax_rate'][$i], $arrValues['tax_rule'][$i]) * $arrValues['quantity'][$i];
+            $tax = SC_Helper_TaxRule_Ex::calcTax($arrValues['price'][$i], $arrValues['tax_rate'][$i], $arrValues['tax_rule'][$i]);
+            $subtotal += ($tax + $arrValues['price'][$i]) * $arrValues['quantity'][$i];
+            // 税額の計算
+            $totaltax += $tax * $arrValues['quantity'][$i];
             // 加算ポイントの計算
             $totalpoint += SC_Utils_Ex::sfPrePoint($arrValues['price'][$i], $arrValues['point_rate'][$i]) * $arrValues['quantity'][$i];
 
@@ -1082,7 +1083,7 @@ class LC_Page_Admin_Order_Edit extends LC_Page_Admin_Order_Ex
             $this->changeShipmentProducts($arrShipmentProducts, $arrAddProductInfo, $select_shipping_id, $change_no);
 
             //受注商品情報も上書き
-            $arrTax = SC_Helper_TaxRule_Ex::getTaxRule(0, $edit_product_class_id);
+            $arrTax = SC_Helper_TaxRule_Ex::getTaxRule($arrAddProductInfo['product_id']);
 
             // 実際はedit
             $arrAddProductInfo['product_name'] = ($arrAddProductInfo['product_name'])
@@ -1260,7 +1261,7 @@ class LC_Page_Admin_Order_Edit extends LC_Page_Admin_Order_Ex
     {
         if (!$arrProductClassIds || !in_array($insert_product_class_id, $arrProductClassIds)) {
             $arrAddProducts = array();
-            $arrTax = SC_Helper_TaxRule_Ex::getTaxRule(0, $insert_product_class_id);
+            $arrTax = SC_Helper_TaxRule_Ex::getTaxRule($arrAddProductInfo['product_id']);
 
             $arrAddProductInfo['product_name'] = ($arrAddProductInfo['product_name'])
                 ? $arrAddProductInfo['product_name']

--- a/data/class/pages/admin/products/LC_Page_Admin_Products_Product.php
+++ b/data/class/pages/admin/products/LC_Page_Admin_Products_Product.php
@@ -315,6 +315,9 @@ class LC_Page_Admin_Products_Product extends LC_Page_Admin_Products_Ex
         $objFormParam->addParam('公開・非公開', 'status', INT_LEN, 'n', array('EXIST_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK'));
         $objFormParam->addParam('商品ステータス', 'product_status', INT_LEN, 'n', array('NUM_CHECK', 'MAX_LENGTH_CHECK'));
 
+        if (OPTION_PRODUCT_TAX_RULE) {
+            $objFormParam->addParam('消費税率', 'tax_rate', PERCENTAGE_LEN, 'n', array('EXIST_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK'));
+        }
         if (!$arrPost['has_product_class']) {
             // 新規登録, 規格なし商品の編集の場合
             $objFormParam->addParam('商品種別', 'product_type_id', INT_LEN, 'n', array('EXIST_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK'));
@@ -325,9 +328,10 @@ class LC_Page_Admin_Products_Product extends LC_Page_Admin_Products_Ex
             $objFormParam->addParam('商品コード', 'product_code', STEXT_LEN, 'KVa', array('EXIST_CHECK', 'SPTAB_CHECK', 'MAX_LENGTH_CHECK'));
             $objFormParam->addParam(NORMAL_PRICE_TITLE, 'price01', PRICE_LEN, 'n', array('NUM_CHECK', 'MAX_LENGTH_CHECK', 'ZERO_START'));
             $objFormParam->addParam(SALE_PRICE_TITLE, 'price02', PRICE_LEN, 'n', array('EXIST_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK', 'ZERO_START'));
-            if (OPTION_PRODUCT_TAX_RULE) {
-                $objFormParam->addParam('消費税率', 'tax_rate', PERCENTAGE_LEN, 'n', array('EXIST_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK'));
-            }
+            // 商品規格ごとの税率設定は廃止
+            // if (OPTION_PRODUCT_TAX_RULE) {
+            //     $objFormParam->addParam('消費税率', 'tax_rate', PERCENTAGE_LEN, 'n', array('EXIST_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK'));
+            // }
             $objFormParam->addParam('在庫数', 'stock', AMOUNT_LEN, 'n', array('SPTAB_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK', 'ZERO_START'));
             $objFormParam->addParam('在庫無制限', 'stock_unlimited', INT_LEN, 'n', array('SPTAB_CHECK', 'NUM_CHECK', 'MAX_LENGTH_CHECK'));
         }
@@ -600,7 +604,7 @@ class LC_Page_Admin_Products_Product extends LC_Page_Admin_Products_Ex
             if ($arrForm['product_id'] == '') {
                 $arrRet = SC_Helper_TaxRule_Ex::getTaxRule();
             } else {
-                $arrRet = SC_Helper_TaxRule_Ex::getTaxRule($arrForm['product_id'], $arrForm['product_class_id']);
+                $arrRet = SC_Helper_TaxRule_Ex::getTaxRule($arrForm['product_id']);
             }
             $arrForm['tax_rate'] = $arrRet['tax_rate'];
         }
@@ -1132,8 +1136,8 @@ __EOF__;
         $objProduct->setProductStatus($product_id, $arrList['product_status']);
 
         // 税情報設定
-        if (OPTION_PRODUCT_TAX_RULE && !$objDb->sfHasProductClass($product_id)) {
-            SC_Helper_TaxRule_Ex::setTaxRuleForProduct($arrList['tax_rate'], $arrList['product_id'], $arrList['product_class_id']);
+        if (OPTION_PRODUCT_TAX_RULE) {
+            SC_Helper_TaxRule_Ex::setTaxRuleForProduct($arrList['tax_rate'], $arrList['product_id'], 0);
         }
 
         // 関連商品登録

--- a/data/class/pages/admin/products/LC_Page_Admin_Products_ProductClass.php
+++ b/data/class/pages/admin/products/LC_Page_Admin_Products_ProductClass.php
@@ -197,9 +197,10 @@ class LC_Page_Admin_Products_ProductClass extends LC_Page_Admin_Ex
         $objFormParam->addParam('在庫数', 'stock_unlimited', INT_LEN, 'n', array('MAX_LENGTH_CHECK', 'NUM_CHECK'));
         $objFormParam->addParam(NORMAL_PRICE_TITLE, 'price01', PRICE_LEN, 'n', array('NUM_CHECK', 'MAX_LENGTH_CHECK'));
         $objFormParam->addParam(SALE_PRICE_TITLE, 'price02', PRICE_LEN, 'n', array('NUM_CHECK', 'MAX_LENGTH_CHECK'));
-        if (OPTION_PRODUCT_TAX_RULE) {
-            $objFormParam->addParam('消費税率', 'tax_rate', PERCENTAGE_LEN, 'n', array('NUM_CHECK', 'MAX_LENGTH_CHECK'));
-        }
+        // 商品規格ごとの税率設定は廃止
+        // if (OPTION_PRODUCT_TAX_RULE) {
+        //     $objFormParam->addParam('消費税率', 'tax_rate', PERCENTAGE_LEN, 'n', array('NUM_CHECK', 'MAX_LENGTH_CHECK'));
+        // }
         $objFormParam->addParam('商品種別', 'product_type_id', INT_LEN, 'n', array('MAX_LENGTH_CHECK', 'NUM_CHECK'));
         $objFormParam->addParam('削除フラグ', 'del_flg', INT_LEN, 'n', array('MAX_LENGTH_CHECK', 'NUM_CHECK'));
         $objFormParam->addParam('ダウンロード販売用ファイル名', 'down_filename', STEXT_LEN, 'KVa', array('MAX_LENGTH_CHECK'));
@@ -278,10 +279,10 @@ class LC_Page_Admin_Products_ProductClass extends LC_Page_Admin_Ex
 
             $objQuery->insert('dtb_products_class', $arrPC);
 
-            // 税情報登録/更新
-            if (OPTION_PRODUCT_TAX_RULE) {
-                SC_Helper_TaxRule_Ex::setTaxRuleForProduct($arrList['tax_rate'][$i], $arrPC['product_id'], $arrPC['product_class_id']);
-            }
+            // 商品規格ごとの税率設定は廃止
+            // if (OPTION_PRODUCT_TAX_RULE) {
+            //     SC_Helper_TaxRule_Ex::setTaxRuleForProduct($arrList['tax_rate'][$i], $arrPC['product_id'], $arrPC['product_class_id']);
+            // }
         }
 
         // 規格無し用の商品規格を非表示に
@@ -352,9 +353,10 @@ class LC_Page_Admin_Products_ProductClass extends LC_Page_Admin_Ex
                 /*
                  * 消費税率の必須チェック
                  */
-                if (OPTION_PRODUCT_TAX_RULE && SC_Utils_Ex::isBlank($arrValues['tax_rate'][$i])) {
-                    $arrErr['tax_rate'][$i] = '※ 消費税率が入力されていません。<br />';
-                }
+                // 商品規格ごとの税率設定は廃止
+                // if (OPTION_PRODUCT_TAX_RULE && SC_Utils_Ex::isBlank($arrValues['tax_rate'][$i])) {
+                //     $arrErr['tax_rate'][$i] = '※ 消費税率が入力されていません。<br />';
+                // }
                 /*
                  * 商品種別の必須チェック
                  */
@@ -498,11 +500,11 @@ class LC_Page_Admin_Products_ProductClass extends LC_Page_Admin_Ex
                     $arrValues['del_flg'] = '0';
                 }
 
-                // 消費税率を設定
-                if (OPTION_PRODUCT_TAX_RULE) {
-                    $arrRet = SC_Helper_TaxRule_Ex::getTaxRule($arrValues['product_id'], $arrValues['product_class_id']);
-                    $arrValues['tax_rate'] = $arrRet['tax_rate'];
-                }
+                // 商品規格ごとの税率設定は廃止
+                // if (OPTION_PRODUCT_TAX_RULE) {
+                //     $arrRet = SC_Helper_TaxRule_Ex::getTaxRule($arrValues['product_id'], $arrValues['product_class_id']);
+                //     $arrValues['tax_rate'] = $arrRet['tax_rate'];
+                // }
 
                 $arrMergeProductsClass[] = $arrValues;
             }


### PR DESCRIPTION
- 実運用で商品規格ごとの税率設定をすることは希と思われるため削除
- `dtb_tax_rule.product_class_id` は常に 0
- https://github.com/EC-CUBE/eccube-2_13/pull/298#issuecomment-522394809
- #99 の問題も解消できる
- 商品別税率 ON の場合、商品一覧、詳細画面で商品規格ごとに SQL がコールされていたのを改善