### PR TITLE
Codeception のサポートクラスを PSR-0 autoloader に追加

### DIFF
--- a/tests/require.php
+++ b/tests/require.php
@@ -25,6 +25,7 @@ $classMap = function ($dir) {
     }
     return $map;
 };
+$loader->add('_generated', __DIR__.'/../ctests/_support');
 $loader->addClassMap($classMap(__DIR__.'/../ctests'));
 $loader->addClassMap($classMap(__DIR__.'/class'));
 return $loader;


### PR DESCRIPTION
- 静的解析ツールなどが正常に動作しなかったのを修正
- ctests/_support 以下のクラスは namespace がついており、 ClassMap が生成されていなかったため個別に追加
- refs #263 
