### PR TITLE
Install to dpkg for trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
     sources:
       - google-chrome
     packages:
+      - dpkg  # see https://github.com/travis-ci/travis-ci/issues/9361
       - google-chrome-stable
 
 env:


### PR DESCRIPTION
PHP5.4, PHP5.5 のテストがエラーになるのを修正
trusty で goolgle-chrome-stable をインストールするために、 最新の dpkg をインストールする必要がある

see https://github.com/travis-ci/travis-ci/issues/9361